### PR TITLE
Port review workflow from riffgrep

### DIFF
--- a/.claude/skills/pull-reviews.md
+++ b/.claude/skills/pull-reviews.md
@@ -9,7 +9,8 @@ description: >
 # Pull Reviews — Fetch GitHub Comments to Local File
 
 Fetch review comments from a GitHub PR and append new ones chronologically
-to the local review file `doc/reviews/review-NNNN.md`.
+to `doc/reviews/review-NNNN.md`. The heavy lifting lives in
+`scripts/pull_reviews.py`; this skill is a thin wrapper around it.
 
 ---
 
@@ -24,90 +25,87 @@ gh pr view --json number --jq .number
 
 If no PR is found, ask the user for the number.
 
-## Step 2: Find the high-water mark
-
-Read `doc/reviews/review-NNNN.md` if it exists. Scan for all
-`<!-- gh-id: NNNNN -->` markers and take the maximum. This is the
-high-water mark — only items with `id` greater than this value are new.
-
-If the file doesn't exist or has no markers, all items are new.
-
-## Step 3: Fetch comments
-
-Fetch all review comments for the PR, sorted by creation time:
+## Step 2: Run the script
 
 ```
-gh api repos/{owner}/{repo}/pulls/{N}/comments \
-  --jq 'sort_by(.created_at) | .[] | {id, user: .user.login, path, line, body, created_at, in_reply_to_id}'
+scripts/pull_reviews.py <N>
 ```
 
-Also fetch top-level review bodies (Copilot summaries, human approvals):
+The script handles everything: fetches reviews and inline comments via
+`gh api --paginate` (so PRs with >30 items aren't truncated), merges
+them chronologically, de-dupes via set membership on `<!-- gh-id: -->`
+markers, hyperlinks headers to GitHub permalinks, absolute-ifies
+relative links in bodies, and creates `review-NNNN.md` with a
+`# PR #N — <title>` header if it doesn't exist.
 
-```
-gh api repos/{owner}/{repo}/pulls/{N}/reviews \
-  --jq 'sort_by(.submitted_at) | .[] | select(.body != "") | {id, user: .user.login, state, body, submitted_at}'
-```
+The script is idempotent: any item whose `gh-id` is already present in
+the file is skipped. Note: it is **not** safe to assume a single
+"high-water mark" — GitHub draws review IDs and inline-comment IDs from
+different sequences, so max-id across both would silently drop later
+items from the lower-numbered sequence. Set membership avoids this.
 
-Filter both lists to only entries with `id` greater than the high-water
-mark.
+## Step 3: Commit the updated file
 
-## Step 4: Format and append
+If new items were appended, **commit `review-NNNN.md` to the PR branch**
+— either as a standalone `doc: update review-NNNN.md` commit or folded
+into the current round's fix commit. The review file must ride along
+with the PR that generated it; landing it post-merge orphans the audit
+trail.
 
-Append new comments **chronologically** (by `created_at` / `submitted_at`)
-to the review file. Each comment is a self-contained block:
+If there were no new items (script reported `no new items`), skip this
+step.
 
-For a top-level review body:
-
-```markdown
-<!-- gh-id: {id} -->
-### {user} — {state} ({YYYY-MM-DD HH:MM UTC})
-
-{body}
-```
-
-For an inline comment (new thread):
-
-```markdown
-<!-- gh-id: {id} -->
-### {user} on `{path}:{line}` ({YYYY-MM-DD HH:MM UTC})
-
-{body}
-```
-
-For a reply (has `in_reply_to_id`):
-
-```markdown
-<!-- gh-id: {id} -->
-#### ↳ {user} ({YYYY-MM-DD HH:MM UTC})
-
-{body}
-```
-
-If the file is new, add a top-level header first:
-
-```markdown
-# PR #{N} — {PR title}
-```
-
-Fetch the PR title via:
-
-```
-gh pr view {N} --json title --jq .title
-```
-
-## Step 5: Report
+## Step 4: Report
 
 Print a one-paragraph summary: how many new comments appended, from
-which reviewers, and the path to the review file.
+which reviewers, and the path to the review file. Pipe through the
+script's stdout if that's easier.
+
+---
+
+## Format contract (for reference / debugging)
+
+The script writes three block shapes. If you're editing the file by hand
+or extending the script, preserve these:
+
+Top-level review body:
+
+```markdown
+<!-- gh-id: {id} -->
+### {user} — {state} ([{YYYY-MM-DD HH:MM UTC}]({html_url}))
+
+{body}
+```
+
+Inline comment (new thread):
+
+```markdown
+<!-- gh-id: {id} -->
+### {user} on [`{path}:{line}`]({html_url}) ({YYYY-MM-DD HH:MM UTC})
+
+{body}
+```
+
+Reply (has `in_reply_to_id`):
+
+```markdown
+<!-- gh-id: {id} -->
+#### ↳ {user} ([{YYYY-MM-DD HH:MM UTC}]({html_url}))
+
+{body}
+```
 
 ## Notes
 
-- **Do not commit the review file.** The user decides when to commit.
-- **Idempotent.** The high-water mark (`gh-id` HTML comments) ensures
-  running twice never duplicates. The agent's only job is: find the
-  largest `gh-id` already in the file, append anything newer.
-- **Chronological, not grouped.** Comments appear in the order they were
-  posted on GitHub. This preserves the conversational flow — a reply
-  appears right after the comment it responds to (since GitHub assigns
-  monotonically increasing ids within a PR). Use `in_reply_to_id` only
-  to decide the `↳ reply` formatting, not to reorder.
+- **The script does not auto-commit.** The agent must stage and commit
+  `review-NNNN.md` on the PR branch when new items were appended (see
+  Step 3). The file must ride along with the PR — don't leave it
+  untracked.
+- **Idempotent** via set membership on `<!-- gh-id: -->` markers (not
+  max-id, which would be unsound across review/comment sequences).
+  Safe to re-run.
+- **Chronological, not grouped.** Items are appended in posted order
+  (by `created_at` / `submitted_at`). Replies are only indicated by
+  `↳` formatting based on `in_reply_to_id`; they are not guaranteed
+  to be adjacent to their parent — other comments posted in between
+  will interleave.

--- a/.claude/skills/reply-reviews.md
+++ b/.claude/skills/reply-reviews.md
@@ -1,0 +1,122 @@
+---
+name: reply-reviews
+description: >
+  After addressing GitHub PR review findings with a fix commit, post
+  short replies to each unresolved comment thread on GitHub. Use when
+  the user says "/reply-reviews <N>", "reply to the review comments",
+  or after landing a fix commit that addresses Copilot/reviewer
+  feedback on a PR.
+---
+
+# Reply Reviews — Post Replies to GitHub Review Threads
+
+Post short, direct replies to PR review comments that have been
+addressed locally but not yet answered on GitHub. This closes the loop
+for the reviewer and leaves a paper trail linking each finding to the
+commit that addressed it.
+
+Intended to run **after** a fix commit that addresses the feedback has
+been pushed — the replies cite the fix commit's SHA.
+
+---
+
+## Step 1: Determine the PR
+
+User provides a PR number (e.g. `/reply-reviews 5`). If omitted, use
+the current branch's open PR:
+
+```
+gh pr view --json number --jq .number
+```
+
+Abort if no PR is found.
+
+## Step 2: Identify unreplied threads
+
+Read `doc/reviews/review-NNNN.md`. A thread is a top-level inline
+comment (a `### {user} on [\`{path}:{line}\`](...)` header) plus any
+`#### ↳ {user}` replies beneath it, terminating at the next `### ` or
+end of file.
+
+A thread is **unreplied** if no `↳` reply in it is authored by a
+non-bot account (i.e., not `Copilot`, not `copilot-pull-request-reviewer[bot]`,
+not `claude[bot]`). Top-level review-body sections (`### {user} — {state}`,
+no `on [\`path:line\`]`) can usually be skipped — they don't take
+threaded replies via the review-comment API.
+
+If the file is stale (you know there's been GH activity since the last
+`/pull-reviews`), run `scripts/pull_reviews.py <N>` first so you're
+replying against current state.
+
+## Step 3: Compose replies
+
+For each unreplied thread, compose a short reply (1–3 sentences) that
+does one of:
+
+- **Acknowledge a fix**: cite the fix commit SHA and briefly name what
+  changed. Example: `Fixed in 3bea723 — switched to set-membership
+  de-dup per your suggestion.`
+- **Accept as follow-up**: explain why it's deferred and where it's
+  tracked. Example: `Good catch, deferred — tracked as a follow-up in
+  PR description. Not blocking this change.`
+- **Push back with reasoning**: if the suggestion is wrong or
+  inapplicable, say why in one sentence without hedging.
+
+Guidance:
+
+- Cite the commit SHA (7 chars) when a fix exists. `git log
+  --oneline origin/main..HEAD` is your source.
+- Don't thank the reviewer. Don't apologize. Don't repeat the comment
+  back.
+- Don't post a reply that just says "done" — name what was done.
+- If multiple comments got fixed by the same commit, each reply should
+  still cite it individually (threads are independent on GitHub).
+
+## Step 4: Post via the script
+
+For each composed reply:
+
+```
+scripts/reply_review.py <PR> <in_reply_to_id> "<body>"
+```
+
+`<in_reply_to_id>` is the `gh-id` from the top-level comment's
+`<!-- gh-id: NNNNN -->` marker in the review file. The script posts
+via `gh api` and prints the new reply's id and URL.
+
+Pass `-` as the body arg to read from stdin for long or multi-line
+replies:
+
+```
+scripts/reply_review.py 5 3098547699 - <<'EOF'
+Fixed in 3bea723 — ...
+EOF
+```
+
+## Step 5: Mirror locally and commit
+
+After posting, run `scripts/pull_reviews.py <N>` to append your replies
+to the local review file. Set-membership de-dup ensures only the new
+replies get added.
+
+Then **commit the updated review file to the PR branch** — either as a
+standalone `doc: update review-NNNN.md` commit or folded into the fix
+commit that addressed the round's findings. The review file must ride
+along with the PR that generated it; landing it post-merge orphans the
+audit trail.
+
+## Step 6: Report
+
+Print a summary: how many threads replied to, and the path to the
+review file. One paragraph max.
+
+## Notes
+
+- **Bots don't count as human replies.** A Copilot `↳ Copilot` reply
+  under its own comment doesn't satisfy "replied". Only a human-authored
+  reply closes the thread.
+- **One reply per thread, not per comment.** If a thread already has
+  your reply buried three deep, don't post another.
+- **The review file belongs on the PR branch.** Every `/pull-reviews`
+  and `/reply-reviews` run that mutates `review-NNNN.md` should end in
+  a commit on the same branch as the PR. Don't leave it untracked.

--- a/.claude/skills/sprint-review.md
+++ b/.claude/skills/sprint-review.md
@@ -2,7 +2,7 @@
 name: sprint-review
 description: >
   Local pre-push code review (Tier 1). Spawns an independent reviewer agent
-  to examine the branch diff against main. Use when the user says
+  to examine the branch diff against `origin/main`. Use when the user says
   "/sprint-review", "review the branch", "review before push", or after
   completing work on a feature branch before pushing to GitHub.
 ---
@@ -12,7 +12,7 @@ description: >
 You are orchestrating a **local, pre-push** code review. This is Tier 1 of
 a two-tier system:
 
-- **Tier 1 (this skill):** Independent agent reviews `main...HEAD` locally.
+- **Tier 1 (this skill):** Independent agent reviews `origin/main...HEAD` locally.
   Gate before pushing.
 - **Tier 2 (GitHub):** After push, CI runs build/test/clippy/fmt. Claude
   Code Action and/or Copilot review the PR on GitHub.
@@ -21,6 +21,21 @@ Your job: gather inputs, launch the reviewer, place the output, then help
 the user push if the review passes.
 
 ---
+
+## Step 0: Autosquash any pending fixups
+
+Per CLAUDE.md, CI-repair commits are made as `--fixup`s and must be
+collapsed before review/push. Refresh the remote-tracking ref first so
+the check isn't against a stale base, then scan for fixups:
+
+```
+git fetch --quiet origin main
+git -c color.ui=never log --oneline origin/main..HEAD | grep -E '^[0-9a-f]+ fixup!' || true
+```
+
+If any fixups exist, run `scripts/autosquash.sh` to collapse them.
+Abort if the working tree is dirty (the script checks this). After
+autosquash, re-run the fixup check to confirm the branch is clean.
 
 ## Step 1: Identify the plan (optional)
 
@@ -38,15 +53,17 @@ in **code-only mode** (no plan-conformance section).
 
 ## Step 2: Collect the diff
 
-The review always targets the current branch against main:
+The review always targets the current branch against `origin/main`.
+Refresh the ref first so the base isn't stale:
 
 ```
-git diff main...HEAD
-git log main..HEAD --oneline
+git fetch --quiet origin main
+git diff origin/main...HEAD
+git log origin/main..HEAD --oneline
 ```
 
-If the branch has not diverged from main, abort with a message — there's
-nothing to review.
+If the branch has not diverged from `origin/main`, abort with a
+message — there's nothing to review.
 
 ## Step 3: Gather context
 
@@ -96,17 +113,17 @@ robot. Good review comments share these qualities:
 ~~~
 You are reviewing code on a local feature branch before it is pushed to
 GitHub. This is a pre-push quality gate — there is no PR yet. You are
-reviewing the diff between main and the branch HEAD.
+reviewing the diff between `origin/main` and the branch HEAD.
 
 You are an independent reviewer. You did not write this code and have no
 context beyond what is provided here. Review what you see, not what you
 assume.
 
-## Diff (main...HEAD)
+## Diff (origin/main...HEAD)
 
 {diff}
 
-## Commit log (main..HEAD)
+## Commit log (origin/main..HEAD)
 
 {commit log}
 
@@ -228,7 +245,7 @@ When the reviewer agent returns:
    ## Local review (YYYY-MM-DD)
 
    **Branch:** <branch>
-   **Commits:** <count> (main..<branch>)
+   **Commits:** <count> (origin/main..<branch>)
    **Reviewer:** Claude (sonnet, independent)
 
    ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,15 @@ foo = ["dep:crate-foo"]
   same commit. Never commit a red test suite.
 - **No merge commits.** Always rebase onto main — never `git merge`. The
   history must be linear.
+- **CI-repair commits must be fixups.** If a commit on this branch broke
+  CI and the follow-up exists only to repair it, commit with
+  `git commit --fixup=<broken-sha>` instead of a standalone `fix:`.
+  Before pushing, run `scripts/autosquash.sh` (a thin wrapper over
+  `GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash origin/main`) so the
+  fixups collapse into their targets. This keeps main's linear history
+  free of commits that temporarily broke the build. Review-round commits
+  (addressing reviewer feedback from an earlier push) remain standalone
+  so the audit trail survives.
 - **No unsafe code**: `#![forbid(unsafe_code)]` when possible.
 - **Test fixtures are gitignored**, and a fresh checkout must pass
   `cargo test --workspace` with zero setup. Tests that depend on a
@@ -91,6 +100,58 @@ task: Add serde to core dependencies
 ```
 
 Keep subjects under 72 characters. Use the body for non-obvious decisions.
+
+## Two-tier review workflow
+
+### Tier 1 — Local review (pre-push)
+
+The coding agent makes atomic commits as it works. Each commit must pass
+`cargo test` and `cargo clippy` (enforced by the pre-commit hook in
+`.claude/settings.json`). Commits can be as small as desired.
+
+Before pushing to GitHub, run `/sprint-review`. This spawns an independent
+reviewer agent that examines `git diff origin/main...HEAD` and the commit
+log. The reviewer flags must-fix issues and follow-ups. The review is
+appended to `doc/reviews/review-NNNN.md`, where `NNNN` is the zero-padded
+PR number for the branch (use `0000` as a placeholder pre-PR and rename
+once the PR is created).
+
+If must-fix items exist, resolve them before pushing. If the review is
+clean, push and create a PR.
+
+### Tier 2 — GitHub review (post-push)
+
+Once pushed, CI runs build, clippy, test, and fmt checks. Claude Code
+Action and/or GitHub Copilot perform a second-round review on the PR
+automatically.
+
+After GitHub review activity, run `/pull-reviews <N>` to fetch the PR's
+review bodies and inline comments and **append them chronologically to the
+same `doc/reviews/review-NNNN.md`** used by Tier 1. The skill is idempotent
+— it records `<!-- gh-id: NNNNN -->` markers for each appended item and
+skips any id already present, so running it repeatedly only appends new
+comments. The result is one file per PR containing the full local + GitHub
+review history in order.
+
+Once the findings are addressed in a fix commit and pushed, run
+`/reply-reviews <N>` to post short replies to each unresolved comment
+thread on GitHub, citing the fix commit SHA. This closes the loop for
+the reviewer and leaves an audit trail linking each finding to its
+resolution. Re-running `/pull-reviews <N>` afterward mirrors the replies
+back into `review-NNNN.md`.
+
+**`review-NNNN.md` rides along with the PR that generated it.** Every
+`/pull-reviews` and `/reply-reviews` round that mutates the file must
+end in a commit on the PR branch (standalone `doc:` commit or folded
+into the round's fix commit). Don't leave it untracked between rounds
+— landing it after merge orphans the audit trail. Before final push,
+run `/pull-reviews <N>` one last time to capture any trailing comments
+and commit the result.
+
+The local review catches design issues and convention violations early.
+The GitHub review catches anything that slipped through and validates in
+the CI environment. Joining them into a single file per PR preserves the
+conversational flow and keeps the review record in one place.
 
 ## TDD workflow
 

--- a/scripts/autosquash.sh
+++ b/scripts/autosquash.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Non-interactively rebase the current branch onto the provided base
+# (default: origin/main), collapsing any `fixup!` commits into their
+# targets via git's autosquash machinery.
+#
+# Use this before pushing a branch that accumulated CI-repair fixups so
+# that main's linear history doesn't gain commits that temporarily broke
+# the build.
+#
+# Usage:
+#     scripts/autosquash.sh [base]
+#
+# `base` defaults to origin/main.
+set -euo pipefail
+
+base="${1:-origin/main}"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: not inside a git worktree" >&2
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree not clean; commit or stash first" >&2
+  exit 1
+fi
+
+if [[ "$base" == */* ]]; then
+  remote="${base%%/*}"
+  branch="${base#*/}"
+  if git remote get-url "$remote" >/dev/null 2>&1 \
+      && git check-ref-format --branch "$branch" >/dev/null 2>&1; then
+    git fetch --quiet "$remote" "$branch"
+  fi
+fi
+
+GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash "$base"

--- a/scripts/pull_reviews.py
+++ b/scripts/pull_reviews.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Fetch GitHub PR review bodies and inline comments and append them
+chronologically to `doc/reviews/review-NNNN.md`.
+
+Idempotent via set-membership on `<!-- gh-id: N -->` markers: any item
+whose id is already present in the target file is skipped. This avoids
+the trap of a single "high-water mark" — GitHub assigns review IDs and
+inline-comment IDs from different sequences, so a max-id across both
+would silently drop later items from the lower-numbered sequence.
+
+Paginated: both `/reviews` and `/comments` use `gh api --paginate` so
+PRs with more than one page of items are fetched fully.
+
+Requires: `gh` CLI authenticated for the current repo.
+
+Usage:
+    scripts/pull_reviews.py <PR_NUMBER> [--repo owner/name] [--out doc/reviews]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+
+def gh_api(path: str) -> list | dict:
+    """Fetch a paginated `gh api` endpoint. With `--paginate --slurp`, list
+    endpoints return a list-of-pages which we flatten; scalar endpoints
+    return a single-element list which we unwrap."""
+    raw = json.loads(
+        subprocess.check_output(["gh", "api", "--paginate", "--slurp", path], text=True)
+    )
+    if not isinstance(raw, list):
+        return raw
+    if not raw:
+        return []
+    if all(isinstance(page, list) for page in raw):
+        flat: list = []
+        for page in raw:
+            flat.extend(page)
+        return flat
+    if len(raw) == 1 and isinstance(raw[0], dict):
+        return raw[0]
+    return raw
+
+
+def gh_repo() -> str:
+    try:
+        return subprocess.check_output(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError:
+        print("error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH", file=sys.stderr)
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        msg = f": {detail}" if detail else ""
+        print(f"error: failed to determine repository via `gh repo view`{msg}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def pr_title(n: int, repo: str | None = None) -> str:
+    cmd = ["gh", "pr", "view", str(n)]
+    if repo is not None:
+        cmd.extend(["--repo", repo])
+    cmd.extend(["--json", "title", "--jq", ".title"])
+    return subprocess.check_output(cmd, text=True).strip()
+
+
+def fmt_ts(t: str) -> str:
+    d = datetime.datetime.fromisoformat(t.replace("Z", "+00:00"))
+    return d.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def existing_ids(path: pathlib.Path) -> set[int]:
+    if not path.exists():
+        return set()
+    return {
+        int(h)
+        for h in re.findall(r"<!-- gh-id: (\d+) -->", path.read_text(encoding="utf-8"))
+    }
+
+
+def absolutize(body: str) -> str:
+    """Rewrite relative GitHub links so they resolve outside github.com."""
+    body = re.sub(r'href="/([^"]*)"', r'href="https://github.com/\1"', body)
+    body = re.sub(r"href='/([^']*)'", r"href='https://github.com/\1'", body)
+    body = re.sub(r"\]\(/(?!/)([^)]*)\)", r"](https://github.com/\1)", body)
+    return body
+
+
+def collect_items(repo: str, n: int) -> list[dict]:
+    items: list[dict] = []
+    for r in gh_api(f"repos/{repo}/pulls/{n}/reviews"):
+        if not r.get("body"):
+            continue
+        items.append(
+            {
+                "kind": "review",
+                "ts": r["submitted_at"],
+                "id": r["id"],
+                "user": r["user"]["login"],
+                "state": r["state"],
+                "body": r["body"],
+                "html_url": r["html_url"],
+            }
+        )
+    for c in gh_api(f"repos/{repo}/pulls/{n}/comments"):
+        items.append(
+            {
+                "kind": "comment",
+                "ts": c["created_at"],
+                "id": c["id"],
+                "user": c["user"]["login"],
+                "path": c["path"],
+                "line": c.get("line"),
+                "body": c["body"],
+                "in_reply_to_id": c.get("in_reply_to_id"),
+                "html_url": c["html_url"],
+            }
+        )
+    items.sort(key=lambda x: x["ts"])
+    return items
+
+
+def render(it: dict) -> str:
+    ts = fmt_ts(it["ts"])
+    body = absolutize(it["body"])
+    url = it["html_url"]
+    out = [f"\n<!-- gh-id: {it['id']} -->"]
+    if it["kind"] == "review":
+        out.append(f"### {it['user']} — {it['state']} ([{ts}]({url}))")
+    else:
+        loc = it["path"] + (f":{it['line']}" if it["line"] else "")
+        if it.get("in_reply_to_id"):
+            out.append(f"#### ↳ {it['user']} ([{ts}]({url}))")
+        else:
+            out.append(f"### {it['user']} on [`{loc}`]({url}) ({ts})")
+    out.append("")
+    out.append(body)
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("pr", type=int, help="PR number")
+    ap.add_argument("--repo", default=None, help="owner/name (default: auto)")
+    ap.add_argument(
+        "--out",
+        default="doc/reviews",
+        help="directory for review-NNNN.md (default: doc/reviews)",
+    )
+    args = ap.parse_args()
+
+    repo = args.repo or gh_repo()
+    out_dir = pathlib.Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"review-{args.pr:04d}.md"
+
+    if not path.exists():
+        path.write_text(
+            f"# PR #{args.pr} — {pr_title(args.pr, repo)}\n", encoding="utf-8"
+        )
+
+    seen = existing_ids(path)
+    new_items = [it for it in collect_items(repo, args.pr) if it["id"] not in seen]
+
+    if not new_items:
+        print(f"PR #{args.pr}: no new items ({len(seen)} already recorded)")
+        return 0
+
+    with path.open("a", encoding="utf-8") as f:
+        for it in new_items:
+            f.write(render(it))
+
+    print(f"PR #{args.pr}: appended {len(new_items)} items -> {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reply_review.py
+++ b/scripts/reply_review.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Post a reply to a PR review comment thread on GitHub.
+
+Wraps `gh api repos/{repo}/pulls/{pr}/comments/{id}/replies -f body=...`
+so the agent doesn't have to remember the endpoint shape. Prints the
+new comment's id and html_url on success.
+
+Requires: `gh` CLI authenticated for the current repo.
+
+Usage:
+    scripts/reply_review.py <PR> <IN_REPLY_TO_ID> <BODY>
+    scripts/reply_review.py <PR> <IN_REPLY_TO_ID> -    # read body from stdin
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def gh_repo() -> str:
+    try:
+        return subprocess.check_output(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError:
+        print("error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH", file=sys.stderr)
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        msg = f": {detail}" if detail else ""
+        print(f"error: failed to determine repository via `gh repo view`{msg}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("pr", type=int, help="PR number")
+    ap.add_argument(
+        "in_reply_to_id",
+        type=int,
+        help="gh-id of the comment you are replying to",
+    )
+    ap.add_argument(
+        "body",
+        help="Reply body (markdown). Pass '-' to read from stdin.",
+    )
+    ap.add_argument("--repo", default=None, help="owner/name (default: auto)")
+    args = ap.parse_args()
+
+    body = sys.stdin.read() if args.body == "-" else args.body
+    body = body.strip()
+    if not body:
+        print("error: empty body", file=sys.stderr)
+        return 1
+
+    repo = args.repo or gh_repo()
+    path = f"repos/{repo}/pulls/{args.pr}/comments/{args.in_reply_to_id}/replies"
+
+    result = subprocess.run(
+        ["gh", "api", "--method", "POST", path, "-f", f"body={body}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        return result.returncode
+
+    data = json.loads(result.stdout)
+    print(f"posted reply id={data['id']} url={data['html_url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Port the full review-loop tooling and conventions that evolved in riffgrep (PRs #5–#9) so new repos bootstrapped from this template start with the whole flow wired up.

**Scripts (new)**
- \`scripts/pull_reviews.py\` — fetch PR review bodies + inline comments via \`gh api --paginate\`, append chronologically to \`doc/reviews/review-NNNN.md\`, de-dupe via set membership on \`<!-- gh-id: -->\` markers, hyperlink headers to GitHub permalinks, absolute-ify relative links. UTF-8 pinned; \`gh_repo()\` errors cleanly when \`gh\` is missing.
- \`scripts/reply_review.py\` — thin wrapper over \`gh api .../comments/{id}/replies\`, reads body from argv or stdin.
- \`scripts/autosquash.sh\` — non-interactive \`rebase -i --autosquash\` with worktree + dirty-tree guards and a conditional remote fetch gated on \`git remote get-url\` + \`git check-ref-format --branch\`.

**Skills**
- \`pull-reviews.md\` — thin wrapper doc delegating to the script.
- \`reply-reviews.md\` (new) — guides the agent to compose short replies, post them, and commit the mirrored review file.
- \`sprint-review.md\` — add Step 0 fixup scan, standardize on \`origin/main\` for the diff/log with an explicit fetch. Template's existing reviewer-voice examples are preserved.

**CLAUDE.md**
- Fixup/autosquash convention added to Repository conventions.
- New \"Two-tier review workflow\" section covering \`/pull-reviews\`, \`/reply-reviews\`, and the \"review file rides along with its PR\" rule.

## Test plan

- [ ] Next repo bootstrapped from this template has the full workflow out of the box.
- [ ] \`scripts/autosquash.sh\` refuses to run in a dirty tree.
- [ ] \`scripts/pull_reviews.py <N>\` on a fresh PR produces \`doc/reviews/review-NNNN.md\`.