### PR TITLE
fix(scripts): portable gh pagination, line-less threads, cleaner errors

### DIFF
--- a/.claude/skills/pull-reviews.md
+++ b/.claude/skills/pull-reviews.md
@@ -77,10 +77,13 @@ Top-level review body:
 {body}
 ```
 
-Inline comment (new thread):
+Inline comment (new thread). The `:line` suffix is omitted when the
+GitHub API returns `line: null` (outdated diff comments or file-level
+comments), so both `{path}` and `{path}:{line}` variants are valid:
 
 ```markdown
 <!-- gh-id: {id} -->
+### {user} on [`{path}`]({html_url}) ({YYYY-MM-DD HH:MM UTC})
 ### {user} on [`{path}:{line}`]({html_url}) ({YYYY-MM-DD HH:MM UTC})
 
 {body}

--- a/.claude/skills/pull-reviews.md
+++ b/.claude/skills/pull-reviews.md
@@ -58,9 +58,10 @@ step.
 
 ## Step 4: Report
 
-Print a one-paragraph summary: how many new comments appended, from
-which reviewers, and the path to the review file. Pipe through the
-script's stdout if that's easier.
+Print a one-paragraph summary: how many new items were appended and
+the path to the review file. The script's own stdout line —
+`PR #N: appended K items -> <path>` — already gives you both, so you
+can pipe it through verbatim if that's easier.
 
 ---
 

--- a/.claude/skills/pull-reviews.md
+++ b/.claude/skills/pull-reviews.md
@@ -31,12 +31,13 @@ If no PR is found, ask the user for the number.
 scripts/pull_reviews.py <N>
 ```
 
-The script handles everything: fetches reviews and inline comments via
-`gh api --paginate` (so PRs with >30 items aren't truncated), merges
-them chronologically, de-dupes via set membership on `<!-- gh-id: -->`
-markers, hyperlinks headers to GitHub permalinks, absolute-ifies
-relative links in bodies, and creates `review-NNNN.md` with a
-`# PR #N — <title>` header if it doesn't exist.
+The script handles everything: fetches reviews and inline comments by
+iterating `?per_page=100&page=N` explicitly against the GitHub API
+(chosen over `gh api --paginate --slurp` because `--slurp` requires
+gh >= 2.47), merges them chronologically, de-dupes via set membership
+on `<!-- gh-id: -->` markers, hyperlinks headers to GitHub permalinks,
+absolute-ifies relative links in bodies, and creates `review-NNNN.md`
+with a `# PR #N — <title>` header if it doesn't exist.
 
 The script is idempotent: any item whose `gh-id` is already present in
 the file is skipped. Note: it is **not** safe to assume a single

--- a/.claude/skills/reply-reviews.md
+++ b/.claude/skills/reply-reviews.md
@@ -34,15 +34,16 @@ Abort if no PR is found.
 ## Step 2: Identify unreplied threads
 
 Read `doc/reviews/review-NNNN.md`. A thread is a top-level inline
-comment (a `### {user} on [\`{path}:{line}\`](...)` header) plus any
-`#### ↳ {user}` replies beneath it, terminating at the next `### ` or
-end of file.
+comment header — either `### {user} on [\`{path}\`](...)` (outdated
+or file-level comments where the GitHub API omits `line`) or
+`### {user} on [\`{path}:{line}\`](...)` — plus any `#### ↳ {user}`
+replies beneath it, terminating at the next `### ` or end of file.
 
 A thread is **unreplied** if no `↳` reply in it is authored by a
 non-bot account (i.e., not `Copilot`, not `copilot-pull-request-reviewer[bot]`,
 not `claude[bot]`). Top-level review-body sections (`### {user} — {state}`,
-no `on [\`path:line\`]`) can usually be skipped — they don't take
-threaded replies via the review-comment API.
+no `on [\`path\`]` / `on [\`path:line\`]`) can usually be skipped —
+they don't take threaded replies via the review-comment API.
 
 If the file is stale (you know there's been GH activity since the last
 `/pull-reviews`), run `scripts/pull_reviews.py <N>` first so you're

--- a/.claude/skills/sprint-review.md
+++ b/.claude/skills/sprint-review.md
@@ -14,8 +14,10 @@ a two-tier system:
 
 - **Tier 1 (this skill):** Independent agent reviews `origin/main...HEAD` locally.
   Gate before pushing.
-- **Tier 2 (GitHub):** After push, CI runs build/test/clippy/fmt. Claude
-  Code Action and/or Copilot review the PR on GitHub.
+- **Tier 2 (GitHub):** After push, CI runs `cargo test --workspace` and
+  `cargo clippy --all-targets -- -D warnings` (see
+  `.github/workflows/ci.yml`). Claude Code Action and/or Copilot review
+  the PR on GitHub.
 
 Your job: gather inputs, launch the reviewer, place the output, then help
 the user push if the review passes.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 debug/
 target/
 Cargo.lock
+__pycache__/
 
 # Editor
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,10 @@ clean, push and create a PR.
 
 ### Tier 2 — GitHub review (post-push)
 
-Once pushed, CI runs build, clippy, test, and fmt checks. Claude Code
-Action and/or GitHub Copilot perform a second-round review on the PR
-automatically.
+Once pushed, CI runs `cargo test --workspace` and
+`cargo clippy --all-targets -- -D warnings` (see
+`.github/workflows/ci.yml`). Claude Code Action and/or GitHub Copilot
+perform a second-round review on the PR automatically.
 
 After GitHub review activity, run `/pull-reviews <N>` to fetch the PR's
 review bodies and inline comments and **append them chronologically to the

--- a/scripts/_gh.py
+++ b/scripts/_gh.py
@@ -1,0 +1,83 @@
+"""Shared helpers for the scripts/pull_reviews.py and scripts/reply_review.py
+GitHub-review CLIs.
+
+Private sibling module so updates land in one place. Scripts invoked as
+`scripts/foo.py` get `scripts/` on `sys.path[0]` automatically, which is
+enough for `from _gh import ...` to resolve without any package setup.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def gh_repo() -> str:
+    """Return the nameWithOwner of the repo for the current working directory."""
+    try:
+        return subprocess.check_output(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError:
+        print(
+            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        msg = f": {detail}" if detail else ""
+        print(
+            f"error: failed to determine repository via `gh repo view`{msg}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def resolve_repo(pr: int, repo_override: str | None) -> str:
+    """Pick the target repo, verifying the PR exists in it.
+
+    If `--repo` was passed, trust it (explicit beats inferred).
+    Otherwise auto-detect via `gh repo view` from cwd, then pre-flight
+    `gh api repos/{repo}/pulls/{pr}`. On 404, error with both the
+    detected repo and cwd so a user whose shell drifted into the wrong
+    directory sees the mismatch immediately instead of getting an
+    opaque 404 from the reply/review endpoints later.
+    """
+    if repo_override:
+        return repo_override
+    repo = gh_repo()
+    try:
+        subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls/{pr}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        print(
+            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        if "Not Found" in detail or "404" in detail:
+            cwd = os.getcwd()
+            print(
+                f"error: PR #{pr} not found in {repo} (repo detected from cwd: {cwd}).\n"
+                f"  If the PR lives in a different repo, pass --repo owner/name.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        msg = f": {detail}" if detail else ""
+        print(
+            f"error: couldn't verify PR #{pr} in {repo} via `gh api`{msg}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return repo

--- a/scripts/pull_reviews.py
+++ b/scripts/pull_reviews.py
@@ -142,10 +142,13 @@ def collect_items(repo: str, n: int) -> list[dict]:
     for r in gh_api(f"repos/{repo}/pulls/{n}/reviews"):
         if not r.get("body"):
             continue
+        submitted_at = r.get("submitted_at")
+        if not submitted_at:
+            continue
         items.append(
             {
                 "kind": "review",
-                "ts": r["submitted_at"],
+                "ts": submitted_at,
                 "id": r["id"],
                 "user": r["user"]["login"],
                 "state": r["state"],

--- a/scripts/pull_reviews.py
+++ b/scripts/pull_reviews.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 import argparse
 import datetime
 import json
-import os
 import pathlib
 import re
 import subprocess
 import sys
+
+from _gh import resolve_repo
 
 
 def gh_api(path: str) -> list | dict:
@@ -73,67 +74,6 @@ def gh_api(path: str) -> list | dict:
             break
         page += 1
     return all_items
-
-
-def gh_repo() -> str:
-    try:
-        return subprocess.check_output(
-            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
-            text=True,
-            stderr=subprocess.PIPE,
-        ).strip()
-    except FileNotFoundError:
-        print("error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH", file=sys.stderr)
-        raise SystemExit(1)
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or "").strip()
-        msg = f": {detail}" if detail else ""
-        print(f"error: failed to determine repository via `gh repo view`{msg}", file=sys.stderr)
-        raise SystemExit(1)
-
-
-def resolve_repo(pr: int, repo_override: str | None) -> str:
-    """Pick the target repo, verifying the PR exists in it.
-
-    If `--repo` was passed, trust it (explicit beats inferred).
-    Otherwise auto-detect via `gh repo view` from cwd, then pre-flight
-    `gh api repos/{repo}/pulls/{pr}`. On 404, error with both the
-    detected repo and cwd so a user whose shell drifted into the wrong
-    directory sees the mismatch immediately instead of getting an
-    opaque 404 from the reply/review endpoints later.
-    """
-    if repo_override:
-        return repo_override
-    repo = gh_repo()
-    try:
-        subprocess.check_output(
-            ["gh", "api", f"repos/{repo}/pulls/{pr}"],
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-    except FileNotFoundError:
-        print(
-            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or "").strip()
-        if "Not Found" in detail or "404" in detail:
-            cwd = os.getcwd()
-            print(
-                f"error: PR #{pr} not found in {repo} (repo detected from cwd: {cwd}).\n"
-                f"  If the PR lives in a different repo, pass --repo owner/name.",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
-        msg = f": {detail}" if detail else ""
-        print(
-            f"error: couldn't verify PR #{pr} in {repo} via `gh api`{msg}",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    return repo
 
 
 def pr_title(n: int, repo: str | None = None) -> str:

--- a/scripts/pull_reviews.py
+++ b/scripts/pull_reviews.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import json
+import os
 import pathlib
 import re
 import subprocess
@@ -89,6 +90,50 @@ def gh_repo() -> str:
         msg = f": {detail}" if detail else ""
         print(f"error: failed to determine repository via `gh repo view`{msg}", file=sys.stderr)
         raise SystemExit(1)
+
+
+def resolve_repo(pr: int, repo_override: str | None) -> str:
+    """Pick the target repo, verifying the PR exists in it.
+
+    If `--repo` was passed, trust it (explicit beats inferred).
+    Otherwise auto-detect via `gh repo view` from cwd, then pre-flight
+    `gh api repos/{repo}/pulls/{pr}`. On 404, error with both the
+    detected repo and cwd so a user whose shell drifted into the wrong
+    directory sees the mismatch immediately instead of getting an
+    opaque 404 from the reply/review endpoints later.
+    """
+    if repo_override:
+        return repo_override
+    repo = gh_repo()
+    try:
+        subprocess.check_output(
+            ["gh", "api", f"repos/{repo}/pulls/{pr}"],
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        print(
+            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        if "Not Found" in detail or "404" in detail:
+            cwd = os.getcwd()
+            print(
+                f"error: PR #{pr} not found in {repo} (repo detected from cwd: {cwd}).\n"
+                f"  If the PR lives in a different repo, pass --repo owner/name.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        msg = f": {detail}" if detail else ""
+        print(
+            f"error: couldn't verify PR #{pr} in {repo} via `gh api`{msg}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return repo
 
 
 def pr_title(n: int, repo: str | None = None) -> str:
@@ -203,7 +248,7 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    repo = args.repo or gh_repo()
+    repo = resolve_repo(args.pr, args.repo)
     out_dir = pathlib.Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"review-{args.pr:04d}.md"

--- a/scripts/pull_reviews.py
+++ b/scripts/pull_reviews.py
@@ -8,8 +8,9 @@ the trap of a single "high-water mark" — GitHub assigns review IDs and
 inline-comment IDs from different sequences, so a max-id across both
 would silently drop later items from the lower-numbered sequence.
 
-Paginated: both `/reviews` and `/comments` use `gh api --paginate` so
-PRs with more than one page of items are fetched fully.
+Paginated via explicit `?per_page=100&page=N` iteration (not
+`gh api --paginate --slurp`, which needs gh >= 2.47), so PRs with
+more than one page of items are fetched fully on any gh version.
 
 Requires: `gh` CLI authenticated for the current repo.
 
@@ -29,24 +30,48 @@ import sys
 
 
 def gh_api(path: str) -> list | dict:
-    """Fetch a paginated `gh api` endpoint. With `--paginate --slurp`, list
-    endpoints return a list-of-pages which we flatten; scalar endpoints
-    return a single-element list which we unwrap."""
-    raw = json.loads(
-        subprocess.check_output(["gh", "api", "--paginate", "--slurp", path], text=True)
-    )
-    if not isinstance(raw, list):
-        return raw
-    if not raw:
-        return []
-    if all(isinstance(page, list) for page in raw):
-        flat: list = []
-        for page in raw:
-            flat.extend(page)
-        return flat
-    if len(raw) == 1 and isinstance(raw[0], dict):
-        return raw[0]
-    return raw
+    """Fetch a list endpoint, iterating pages explicitly.
+
+    We don't use `gh api --paginate --slurp` because `--slurp` needs gh
+    >= 2.47. Explicit `?page=N&per_page=100` iteration works on every
+    version and is trivially inspectable.
+
+    If the endpoint returns a dict (non-list), we return it as-is from
+    page 1 without continuing to page.
+    """
+    all_items: list = []
+    page = 1
+    while True:
+        sep = "&" if "?" in path else "?"
+        paged = f"{path}{sep}per_page=100&page={page}"
+        try:
+            raw = json.loads(
+                subprocess.check_output(
+                    ["gh", "api", paged], text=True, stderr=subprocess.PIPE
+                )
+            )
+        except FileNotFoundError:
+            print(
+                "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or "").strip()
+            msg = f": {detail}" if detail else ""
+            print(
+                f"error: `gh api` failed for endpoint `{paged}`{msg}", file=sys.stderr
+            )
+            raise SystemExit(1)
+        if not isinstance(raw, list):
+            return raw
+        if not raw:
+            break
+        all_items.extend(raw)
+        if len(raw) < 100:
+            break
+        page += 1
+    return all_items
 
 
 def gh_repo() -> str:
@@ -71,7 +96,23 @@ def pr_title(n: int, repo: str | None = None) -> str:
     if repo is not None:
         cmd.extend(["--repo", repo])
     cmd.extend(["--json", "title", "--jq", ".title"])
-    return subprocess.check_output(cmd, text=True).strip()
+    try:
+        return subprocess.check_output(cmd, text=True, stderr=subprocess.PIPE).strip()
+    except FileNotFoundError:
+        print(
+            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        msg = f": {detail}" if detail else ""
+        target = f"PR #{n}" + (f" in {repo}" if repo else "")
+        print(
+            f"error: failed to determine title for {target} via `gh pr view`{msg}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
 
 def fmt_ts(t: str) -> str:

--- a/scripts/reply_review.py
+++ b/scripts/reply_review.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
@@ -35,6 +36,50 @@ def gh_repo() -> str:
         msg = f": {detail}" if detail else ""
         print(f"error: failed to determine repository via `gh repo view`{msg}", file=sys.stderr)
         raise SystemExit(1)
+
+
+def resolve_repo(pr: int, repo_override: str | None) -> str:
+    """Pick the target repo, verifying the PR exists in it.
+
+    If `--repo` was passed, trust it (explicit beats inferred).
+    Otherwise auto-detect via `gh repo view` from cwd, then pre-flight
+    `gh api repos/{repo}/pulls/{pr}`. On 404, error with both the
+    detected repo and cwd so a user whose shell drifted into the wrong
+    directory sees the mismatch immediately instead of getting an
+    opaque 404 from the reply endpoint later.
+    """
+    if repo_override:
+        return repo_override
+    repo = gh_repo()
+    try:
+        subprocess.check_output(
+            ["gh", "api", f"repos/{repo}/pulls/{pr}"],
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        print(
+            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        if "Not Found" in detail or "404" in detail:
+            cwd = os.getcwd()
+            print(
+                f"error: PR #{pr} not found in {repo} (repo detected from cwd: {cwd}).\n"
+                f"  If the PR lives in a different repo, pass --repo owner/name.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        msg = f": {detail}" if detail else ""
+        print(
+            f"error: couldn't verify PR #{pr} in {repo} via `gh api`{msg}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return repo
 
 
 def main() -> int:
@@ -58,7 +103,7 @@ def main() -> int:
         print("error: empty body", file=sys.stderr)
         return 1
 
-    repo = args.repo or gh_repo()
+    repo = resolve_repo(args.pr, args.repo)
     path = f"repos/{repo}/pulls/{args.pr}/comments/{args.in_reply_to_id}/replies"
 
     try:

--- a/scripts/reply_review.py
+++ b/scripts/reply_review.py
@@ -61,14 +61,23 @@ def main() -> int:
     repo = args.repo or gh_repo()
     path = f"repos/{repo}/pulls/{args.pr}/comments/{args.in_reply_to_id}/replies"
 
-    result = subprocess.run(
-        ["gh", "api", "--method", "POST", path, "-f", f"body={body}"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        sys.stderr.write(result.stderr)
-        return result.returncode
+    try:
+        result = subprocess.run(
+            ["gh", "api", "--method", "POST", path, "-f", f"body={body}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        print(
+            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
+            file=sys.stderr,
+        )
+        return 1
+    except subprocess.CalledProcessError as exc:
+        if exc.stderr:
+            sys.stderr.write(exc.stderr)
+        return exc.returncode or 1
 
     data = json.loads(result.stdout)
     print(f"posted reply id={data['id']} url={data['html_url']}")

--- a/scripts/reply_review.py
+++ b/scripts/reply_review.py
@@ -16,70 +16,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
 import sys
 
-
-def gh_repo() -> str:
-    try:
-        return subprocess.check_output(
-            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
-            text=True,
-            stderr=subprocess.PIPE,
-        ).strip()
-    except FileNotFoundError:
-        print("error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH", file=sys.stderr)
-        raise SystemExit(1)
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or "").strip()
-        msg = f": {detail}" if detail else ""
-        print(f"error: failed to determine repository via `gh repo view`{msg}", file=sys.stderr)
-        raise SystemExit(1)
-
-
-def resolve_repo(pr: int, repo_override: str | None) -> str:
-    """Pick the target repo, verifying the PR exists in it.
-
-    If `--repo` was passed, trust it (explicit beats inferred).
-    Otherwise auto-detect via `gh repo view` from cwd, then pre-flight
-    `gh api repos/{repo}/pulls/{pr}`. On 404, error with both the
-    detected repo and cwd so a user whose shell drifted into the wrong
-    directory sees the mismatch immediately instead of getting an
-    opaque 404 from the reply endpoint later.
-    """
-    if repo_override:
-        return repo_override
-    repo = gh_repo()
-    try:
-        subprocess.check_output(
-            ["gh", "api", f"repos/{repo}/pulls/{pr}"],
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-    except FileNotFoundError:
-        print(
-            "error: `gh` CLI not found; install GitHub CLI and ensure it is on PATH",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or "").strip()
-        if "Not Found" in detail or "404" in detail:
-            cwd = os.getcwd()
-            print(
-                f"error: PR #{pr} not found in {repo} (repo detected from cwd: {cwd}).\n"
-                f"  If the PR lives in a different repo, pass --repo owner/name.",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
-        msg = f": {detail}" if detail else ""
-        print(
-            f"error: couldn't verify PR #{pr} in {repo} via `gh api`{msg}",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    return repo
+from _gh import resolve_repo
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
Three fixes to the review scripts + skill contracts, surfaced while running them on a downstream repo's first real PR round (ephemeris-net/linklab#22).

- **Portable gh pagination.** `gh api --paginate --slurp` needs `gh >= 2.47`; Debian's 2.46 package doesn't have `--slurp` and crashes the script with `unknown flag: --slurp`. Switched `pull_reviews.py` to explicit `?per_page=100&page=N` iteration — works on every `gh` version and is trivially inspectable. Docstring updated.
- **Line-less inline comments.** GitHub returns `line: null` for outdated diff comments and file-level comments. `pull_reviews.py` already renders those as `### user on [\`{path}\`](...)` (no `:line` suffix), but `reply-reviews.md`'s thread-match contract and `pull-reviews.md`'s format contract only documented the `:line` shape. Result: `/reply-reviews` silently skipped those threads. Loosened both contracts to accept `{path}` with or without `:{line}`.
- **Cleaner error surfaces.** `gh_api()`, `pr_title()`, and the reply-posting call in `reply_review.py` all called `subprocess.check_output` / `subprocess.run` without handling `FileNotFoundError` or `CalledProcessError` — missing `gh` or a failing API call produced a Python traceback instead of the one-line `error:` message that `gh_repo()` already emits. Wrapped each in try/except matching the existing pattern.

## Test plan
- [x] `scripts/pull_reviews.py <N>` succeeds on gh 2.46 against a PR with Copilot reviews (verified against linklab#22 — 9 items fetched on first run, 0 on re-run, idempotent via gh-id set-membership).
- [x] `scripts/reply_review.py <PR> <id> "<body>"` successfully posts replies (verified — 8 replies posted and mirrored back via `pull_reviews.py`).
- [x] Re-running `pull_reviews.py` after replies are posted appends exactly those replies and no duplicates.
- [ ] Verify error-handling paths by running with `PATH=` stripped of `gh` (expect clean `error: gh CLI not found` exit, no traceback).