### PR TITLE
fix(_gh): Clarify 404 message — cwd drift OR missing access

### DIFF
--- a/scripts/_gh.py
+++ b/scripts/_gh.py
@@ -68,11 +68,17 @@ def resolve_repo(pr: int, repo_override: str | None) -> str:
         detail = (exc.stderr or "").strip()
         if "Not Found" in detail or "404" in detail:
             cwd = os.getcwd()
-            print(
-                f"error: PR #{pr} not found in {repo} (repo detected from cwd: {cwd}).\n"
-                f"  If the PR lives in a different repo, pass --repo owner/name.",
-                file=sys.stderr,
-            )
+            lines = [
+                f"error: couldn't verify PR #{pr} in {repo} "
+                f"(repo detected from cwd: {cwd}).",
+                "  The PR may be in a different repo — pass "
+                "--repo owner/name to override.",
+                "  A 404 here can also mean your gh token lacks access "
+                "to this repo/PR.",
+            ]
+            if detail:
+                lines.append(f"  gh api detail: {detail}")
+            print("\n".join(lines), file=sys.stderr)
             raise SystemExit(1)
         msg = f": {detail}" if detail else ""
         print(


### PR DESCRIPTION
## Summary
The `resolve_repo()` 404 branch assumed a 404 always meant "wrong repo (cwd drift)" and told the user to pass `--repo owner/name`. But GitHub also returns 404 when your gh token lacks access to the repo/PR (private repo, expired auth, SSO not approved). The old message misled users in that second case.

Rewrite the message to name both possibilities explicitly, and append the raw `gh api` stderr so the reader can tell which case they're in without re-running anything. Output now looks like:

```
error: couldn't verify PR #23 in cmk/template-rust
  (repo detected from cwd: /path).
  The PR may be in a different repo — pass --repo owner/name to override.
  A 404 here can also mean your gh token lacks access to this repo/PR.
  gh api detail: gh: Not Found (HTTP 404)
```

## Test plan
- [x] Trigger the 404 branch by running `pull_reviews.py <N>` against a PR that does not exist in the detected repo — confirms the new message shape.
- [ ] Private-repo access case exercised on a real unauthenticated scenario to confirm wording lands right.

Mirrors the same fix landed on a downstream repo's PR.
