### PR TITLE
Clarify review file rides with next round's fix commit

### DIFF
--- a/.claude/skills/pull-reviews.md
+++ b/.claude/skills/pull-reviews.md
@@ -45,16 +45,27 @@ the file is skipped. Note: it is **not** safe to assume a single
 different sequences, so max-id across both would silently drop later
 items from the lower-numbered sequence. Set membership avoids this.
 
-## Step 3: Commit the updated file
+## Step 3: Let the file ride with the next fix commit
 
-If new items were appended, **commit `review-NNNN.md` to the PR branch**
-— either as a standalone `doc: update review-NNNN.md` commit or folded
-into the current round's fix commit. The review file must ride along
-with the PR that generated it; landing it post-merge orphans the audit
-trail.
+The review file is not committed on its own. It rides with the **next
+round's fix commit** — the commit that addresses the comments you just
+pulled. The rhythm is:
 
-If there were no new items (script reported `no new items`), skip this
-step.
+- Round N-1: reviewer leaves comments → `pull_reviews.py` appends them
+  to `review-NNNN.md`.
+- Round N: you fix what warrants a fix → the fix commit stages the
+  updated `review-NNNN.md` alongside the code changes.
+- If round N is itself no-op (all push-back, no fix), there is no fix
+  commit and nothing to push. The GitHub thread is the canonical record
+  until a later round forces a commit anyway.
+
+So after running this skill: leave `review-NNNN.md` staged/unstaged on
+the branch. Do **not** open a standalone `doc: update review-NNNN.md`
+commit just to land it — that forces a CI round-trip for no code change.
+The fix commit that addresses this round's findings is the vehicle.
+
+If there were no new items (script reported `no new items`), there is
+nothing to stage.
 
 ## Step 4: Report
 
@@ -102,10 +113,9 @@ Reply (has `in_reply_to_id`):
 
 ## Notes
 
-- **The script does not auto-commit.** The agent must stage and commit
-  `review-NNNN.md` on the PR branch when new items were appended (see
-  Step 3). The file must ride along with the PR — don't leave it
-  untracked.
+- **The script does not auto-commit.** The file rides with the next
+  round's fix commit (see Step 3); don't land a standalone `doc:`
+  commit just to attach the audit trail.
 - **Idempotent** via set membership on `<!-- gh-id: -->` markers (not
   max-id, which would be unsound across review/comment sequences).
   Safe to re-run.

--- a/.claude/skills/pull-reviews.md
+++ b/.claude/skills/pull-reviews.md
@@ -48,21 +48,24 @@ items from the lower-numbered sequence. Set membership avoids this.
 ## Step 3: Let the file ride with the next fix commit
 
 The review file is not committed on its own. It rides with the **next
-round's fix commit** — the commit that addresses the comments you just
-pulled. The rhythm is:
+review round's fix commit** — the commit that addresses the comments
+you just pulled. Using `R` for review rounds (distinct from `N`, which
+is the PR number throughout the docs), the rhythm is:
 
-- Round N-1: reviewer leaves comments → `pull_reviews.py` appends them
-  to `review-NNNN.md`.
-- Round N: you fix what warrants a fix → the fix commit stages the
+- Round R: reviewer leaves comments → `scripts/pull_reviews.py`
+  appends them to `review-NNNN.md`.
+- Round R+1: you fix what warrants a fix → the fix commit stages the
   updated `review-NNNN.md` alongside the code changes.
-- If round N is itself no-op (all push-back, no fix), there is no fix
-  commit and nothing to push. The GitHub thread is the canonical record
-  until a later round forces a commit anyway.
+- If round R+1 is itself no-op (all push-back, no fix), there is no
+  fix commit and nothing to push. The GitHub thread is the canonical
+  record until a later round forces a commit anyway.
 
-So after running this skill: leave `review-NNNN.md` staged/unstaged on
-the branch. Do **not** open a standalone `doc: update review-NNNN.md`
-commit just to land it — that forces a CI round-trip for no code change.
-The fix commit that addresses this round's findings is the vehicle.
+So after running this skill: keep `review-NNNN.md` modified but
+uncommitted until the fix commit is ready, then stage it alongside the
+code changes for that commit. Do **not** open a standalone
+`doc: update review-NNNN.md` commit just to land it — that forces a CI
+round-trip for no code change. The fix commit that addresses this
+round's findings is the vehicle.
 
 If there were no new items (script reported `no new items`), there is
 nothing to stage.

--- a/.claude/skills/reply-reviews.md
+++ b/.claude/skills/reply-reviews.md
@@ -15,8 +15,11 @@ addressed locally but not yet answered on GitHub. This closes the loop
 for the reviewer and leaves a paper trail linking each finding to the
 commit that addressed it.
 
-Intended to run **after** a fix commit that addresses the feedback has
-been pushed — the replies cite the fix commit's SHA.
+Intended to run **after** a fix commit that addresses the feedback
+exists locally — the replies cite the fix commit's SHA. Running before
+the branch is pushed lets the mirrored replies ride with the fix
+commit (via `--amend` if needed); running after the push is fine too,
+but the mirror then waits for the next round's fix commit to carry it.
 
 ---
 
@@ -107,7 +110,7 @@ covers — never as a standalone `doc:` commit.
 code changed — there is no fix commit to ride on, so there is nothing
 to push. Skip the mirror step. The GitHub thread is the canonical
 record; a later round's fix commit can pick up all pending replies via
-one `pull_reviews.py` run at that time. Don't force-push solely to
+one `scripts/pull_reviews.py` run at that time. Don't force-push solely to
 attach an audit trail.
 
 ## Step 6: Report
@@ -125,5 +128,5 @@ review file. One paragraph max.
 - **The review file rides with fix commits, not standalone.** A mutated
   `review-NNNN.md` lands as part of the next round's fix commit. If a
   round produces no fix, the file stays on disk uncommitted; a later
-  round's fix picks up all pending replies via one `pull_reviews.py`
-  run at commit time.
+  round's fix picks up all pending replies via one
+  `scripts/pull_reviews.py` run at commit time.

--- a/.claude/skills/reply-reviews.md
+++ b/.claude/skills/reply-reviews.md
@@ -94,35 +94,21 @@ Fixed in 3bea723 — ...
 EOF
 ```
 
-## Step 5: Mirror locally and commit
+## Step 5: Mirror replies — only if there's a fix commit
 
-After posting, run `scripts/pull_reviews.py <N>` to append your replies
-to the local review file. Set-membership de-dup ensures only the new
-replies get added.
+If this round produced a fix commit (one or more threads got real
+changes), run `scripts/pull_reviews.py <N>` after posting to append
+your replies to `review-NNNN.md`, then **stage the updated file as part
+of the same fix commit** (or amend it in before pushing). The review
+file always rides with the fix commit that addresses the round it
+covers — never as a standalone `doc:` commit.
 
-Then **commit the updated review file to the PR branch** — either as a
-standalone `doc: update review-NNNN.md` commit or folded into the fix
-commit that addressed the round's findings. The review file must ride
-along with the PR that generated it; landing it post-merge orphans the
-audit trail.
-
-### No-op rounds (all push-back, no fix commit)
-
-When a review round is entirely push-back — every comment is stale,
-incorrect, or otherwise doesn't warrant a code change — there is no fix
-commit to cite, and forcing a `doc:` commit just to mirror the replies
-adds a round-trip of CI without changing the code. In that case:
-
-- Post the replies via Step 4 as usual.
-- **Skip the mirror-and-commit step** unless the user asks for it
-  explicitly. The GitHub thread is the canonical record; re-pulling
-  later would still pick the replies up idempotently if the audit
-  trail becomes useful.
-- Do not force-push the branch solely to attach the mirrored replies.
-
-This applies only when the entire round is no-op. If even one thread
-gets a real fix, the fix commit goes up and the mirror rides with it
-per the normal flow.
+**If this round is entirely no-op** — every thread got push-back, no
+code changed — there is no fix commit to ride on, so there is nothing
+to push. Skip the mirror step. The GitHub thread is the canonical
+record; a later round's fix commit can pick up all pending replies via
+one `pull_reviews.py` run at that time. Don't force-push solely to
+attach an audit trail.
 
 ## Step 6: Report
 
@@ -136,6 +122,8 @@ review file. One paragraph max.
   reply closes the thread.
 - **One reply per thread, not per comment.** If a thread already has
   your reply buried three deep, don't post another.
-- **The review file belongs on the PR branch.** Every `/pull-reviews`
-  and `/reply-reviews` run that mutates `review-NNNN.md` should end in
-  a commit on the same branch as the PR. Don't leave it untracked.
+- **The review file rides with fix commits, not standalone.** A mutated
+  `review-NNNN.md` lands as part of the next round's fix commit. If a
+  round produces no fix, the file stays on disk uncommitted; a later
+  round's fix picks up all pending replies via one `pull_reviews.py`
+  run at commit time.


### PR DESCRIPTION
## Summary

Tighten `pull-reviews` Step 3 and `reply-reviews` Step 5 so the sequencing is unambiguous: the review file **never** lands as a standalone `doc:` commit. Round N-1's reviewer comments get pulled into `review-NNNN.md`; round N's fix commit stages the updated file alongside the code. If a round is itself no-op, there's no fix commit and nothing to push — the GitHub thread stays canonical, and a later round's fix picks up pending replies via a single `pull_reviews.py` at commit time.

Replaces earlier wording that permitted a separate `doc: update review-NNNN.md` commit. The no-op carve-out is now the direct consequence of "rides with the fix," not an added special case.

## Test plan

- [ ] Next review cycle: confirm the pulled file sits uncommitted on the branch until the fix commit is ready, and lands as part of that commit rather than as a standalone `doc:` commit.
- [ ] Confirm a no-op round leaves the branch clean (no force-push, no extra CI trip).