### PR TITLE
Restructure review-round FSM: drop replies_amended, sprint-review autonomy, safe_merge guard

### DIFF
--- a/.claude/commands/pull-reviews.md
+++ b/.claude/commands/pull-reviews.md
@@ -51,22 +51,22 @@ the file is skipped. Note: it is **not** safe to assume a single
 different sequences, so max-id across both would silently drop later
 items from the lower-numbered sequence. Set membership avoids this.
 
-## Step 3: Let the file ride with the next fix commit
+## Step 3: Let the file ride with the next round commit
 
 The review file is not committed on its own. It rides with the **next
-review round's fix commit** — the commit that addresses the comments
-you just pulled.
+review round's commit** — the atomic commit that bundles the code
+fixes, posted replies, and mirrored doc together.
 
 The `/reply-reviews` command enforces this: it posts replies, runs
-`pull_reviews.py`, and `git commit --amend`s the mutated doc into the
-pre-push fix commit, so one push delivers everything in order.
+`pull_reviews.py` to mirror them, then `git add -A && git commit`s
+everything in one shot. One push delivers the whole round.
 
 If you invoked `/pull-reviews` standalone (no paired reply round), the
 file stays modified-but-uncommitted on disk. A later `/reply-reviews`
 will pick it up and fold it in. Do **not** open a standalone
 `doc: update review-NNNNN.md` commit just to land it — that forces a CI
-round-trip for no code change and was the ordering bug the unified
-`/reply-reviews` was designed to eliminate.
+round-trip for no code change and breaks the one-commit-per-round
+atomicity that the unified `/reply-reviews` exists to provide.
 
 If there were no new items (script reported `no new items`), there is
 nothing staged and nothing to do.
@@ -118,7 +118,7 @@ Reply (has `in_reply_to_id`):
 ## Notes
 
 - **The script does not auto-commit.** The file rides with the next
-  round's fix commit (see Step 3); don't land a standalone `doc:`
+  round's atomic commit (see Step 3); don't land a standalone `doc:`
   commit just to attach the audit trail.
 - **Idempotent** via set membership on `<!-- gh-id: -->` markers (not
   max-id, which would be unsound across review/comment sequences).

--- a/.claude/commands/reply-reviews.md
+++ b/.claude/commands/reply-reviews.md
@@ -1,20 +1,23 @@
 ---
-description: Finalize a PR review round before push. Posts replies to each unresolved thread, mirrors the replies back into review-NNNNN.md via pull_reviews.py, and folds the mutated doc into the round's fix commit via git commit --amend. One push delivers the whole round. Refuses to run if the fix commit was already pushed (which would force an extra commit or force-push).
+description: Finalize a PR review round before push. Apply fix edits to the working tree first, then run this command — it posts replies, mirrors them back into review-NNNNN.md via pull_reviews.py, and produces ONE atomic commit containing both the code fix and the mirrored reply doc. One push delivers the whole round. Refuses to run if the branch already has unpushed commits (which would create a bisect-bisecting two-commit round).
 argument-hint: <pr-number>
 ---
 
 # /reply-reviews — Finalize a Review Round (Before Push)
 
-Posts short replies to each unresolved PR review thread, mirrors them
-back into `doc/reviews/review-NNNNN.md`, and folds the resulting doc
-update into the round's **unpushed** fix commit. Stops before `git push`
-— the user runs that explicitly as the last step, so one push delivers
-code + replies + review doc.
+Apply fix edits to the working tree, then run this command. It posts
+replies to each unresolved PR review thread, mirrors them back into
+`doc/reviews/review-NNNNN.md`, and produces **one atomic commit**
+containing both the code fix and the mirrored reply doc. Stops before
+`git push` — the user runs that explicitly as the last step, so one
+push delivers code + replies + review doc.
 
-This ordering — fix → reply → mirror → amend → push — is deliberate.
-Pushing before the mirror strands the reply-mirror in the working tree
-and forces either a wasted `doc:` commit (extra CI round-trip) or a
-force-push that this workflow is designed to avoid.
+This ordering — **fix-edits (uncommitted) → reply → mirror → atomic
+commit → push** — is deliberate. The `replies_amended` state from the
+older flow is gone: replies and code are bundled into a single commit
+by construction, so the only state between "round started" and
+"round pushed" is `round_unpushed`. There is no `--amend` step and no
+opportunity for replies and fix to diverge.
 
 Target PR: `$ARGUMENTS`
 
@@ -37,47 +40,48 @@ gh pr view --json number --jq .number
 
 Abort if neither yields a number.
 
-### 0b. Fix commit must be unpushed
+### 0b. Branch must be at `gh_review` (no unpushed commits)
 
-The whole premise of this command is amending the fix commit with the
-review-doc update, which is only safe while the commit is local-only.
-Check:
+Per `doc/workflow.md`, this command runs on the
+`gh_review → items_pulled → round_unpushed` arrow — starting from
+`gh_review`, which means the local branch is at-or-behind origin.
+A pre-existing unpushed commit means a previous round didn't push,
+and bundling another round on top would produce a two-commit round
+that's harder to bisect and doesn't fit the FSM.
 
 ```
 branch=$(git branch --show-current)
 git fetch --quiet origin "$branch" || true
-git log "origin/$branch..HEAD" --oneline
+unpushed=$(git log "origin/$branch..HEAD" --oneline)
 ```
 
-- If there are **unpushed commits**: proceed. The last one is assumed
-  to be the fix commit for this round. (If it's not — e.g., you made
-  an unrelated commit after the fix — stop and tell the user to reorder
-  first.)
-- If there are **no unpushed commits** and there are unreplied threads:
-  **refuse**. The fix commit was already pushed, which is the workflow
-  bug this command prevents. Print:
-  > Fix commit has already been pushed for PR #N. To avoid an extra
-  > `doc:` commit or a force-push, the intended ordering is: make the
-  > fix commit → run `/reply-reviews` → `git push`. Recovery options:
-  > (a) post replies manually via `scripts/reply_review.py` and accept
-  > a later round will pick up the mirror; (b) make a new fix commit
-  > that bundles something worth committing plus the mirror, then run
-  > `/reply-reviews` again.
+- If `unpushed` is non-empty: **refuse**. Print:
+  > Branch '$branch' has unpushed commits. Per doc/workflow.md, a new
+  > review round starts from `gh_review` — push the existing commit
+  > first (`git push`), then re-run `/reply-reviews`. If the existing
+  > commit is itself a stale round-1, just push it.
 
-  Do not post replies. Do not force-push.
+  Do not post replies.
 
 ### 0c. Working tree sanity
 
-Run `git status`. If any path other than `doc/reviews/review-NNNNN.md`
-has uncommitted changes, stop and ask the user to commit or stash
-first. The amend in Step 6 is surgical — it shouldn't sweep up
-unrelated dirty files.
+Run `git status`. The working tree may be **dirty with the round's fix
+edits** — that's expected and is exactly what this command bundles
+into the round commit. No constraint on which paths can be dirty;
+trust the user not to bundle unrelated changes. The pre-commit hook
+(Step 6) will catch test/clippy/PII regressions.
+
+If the working tree is **clean**, this is a no-op-code round (all
+push-back / defer). Proceed normally — the round commit will be a
+`doc:`-prefixed commit containing only the mirrored reply doc, which
+is fine and does not break the FSM.
 
 ## Step 1: Refresh the review doc before deciding what to reply to
 
 Even though we'll run `pull_reviews.py` again in Step 5 to mirror our
 own replies, run it **first** so the "unreplied threads" analysis is
-against the latest GitHub state:
+against the latest GitHub state and so partial-failure recovery
+(see Recovery section below) works correctly:
 
 ```
 scripts/pull_reviews.py <N>
@@ -111,8 +115,9 @@ API.
 For each unreplied thread, write 1–3 sentences that do exactly one of:
 
 - **Acknowledge a fix**: name what changed. Example: `Fixed — switched
-  to set-membership de-dup per your suggestion.` Citing the fix commit
-  SHA is optional; naming the change is what matters.
+  to set-membership de-dup per your suggestion.` Citing the eventual
+  round commit SHA is fine but optional (you don't have it yet at this
+  step); naming the change is what matters.
 - **Accept as follow-up**: explain the deferral and where it's tracked.
   Example: `Deferred — tracked as a follow-up in the PR description.
   Not blocking this change.`
@@ -144,6 +149,11 @@ Fixed — ...
 EOF
 ```
 
+If any post fails (network, rate limit, auth): **abort before mirror
+and commit**. The working tree still has the uncommitted code edits.
+See the Recovery section for the re-run shape — it's clean because
+Step 1 + Step 2's filter dedupes already-posted threads.
+
 ## Step 5: Mirror the replies back into the review doc
 
 ```
@@ -153,48 +163,109 @@ scripts/pull_reviews.py <N>
 The script appends the replies you just posted (plus anything else new)
 to `review-NNNNN.md` via set-membership de-dup — safe to re-run.
 
-## Step 6: Fold the doc update into the round's fix commit
+## Step 6: Atomic round commit
+
+Stage everything in the working tree (code edits + mirrored doc) and
+make ONE commit, but **only if there are staged changes** — an
+all-`ask` round with no doc delta produces nothing to commit:
 
 ```
-git add doc/reviews/review-NNNNN.md
-git commit --amend --no-edit
+git add -A
+if git diff --cached --quiet; then
+    # Nothing staged — no replies posted (e.g., all `ask`) and no
+    # doc delta from Step 5. Branch stays at gh_review. Step 7's
+    # "no commit" report branch fires.
+    :
+else
+    # Pick the prefix that matches the staged content:
+    #   fix:  any code edit (most common)
+    #   doc:  only doc/reviews/<file>.md changed (replies-only round)
+    git commit -m "fix: Address review feedback on PR #<N>"
+fi
 ```
 
-This works because Step 0b confirmed the fix commit is unpushed. No
-force-push. If the amend is a no-op (Step 5 appended nothing new —
-unlikely but possible if replies were trivially duplicated), just skip
-the amend.
+The pre-commit hook runs `cargo fmt --check`, `scripts/check-pii.sh`,
+`cargo test --workspace`, and `cargo clippy --all-targets -- -D
+warnings`. If it fails:
+
+- Read the failure. Fix the code or revert the offending edit.
+- Retry `git commit` — staging is preserved.
+- Replies are already on GitHub (Step 4 succeeded). Don't try to
+  un-post; just commit when ready.
+
+There is no `--amend` step. The commit either succeeds (whole round
+captured, state advances to `round_unpushed`) or:
+
+- The pre-commit hook fails: working tree still dirty, replies on
+  GitHub but no mirror committed yet — re-run `/reply-reviews` to
+  redo Step 5+6.
+- Nothing was staged: branch stays at `gh_review`. No state change.
 
 ## Step 7: Report and hand off to the user
 
-Print a one-paragraph summary:
+Print a one-paragraph summary that **names the FSM state from
+`doc/workflow.md`** so the read-out reflects what's actually true on
+the wire. Two terminal shapes:
+
+**If Step 6 made a commit:**
 
 - Number of threads replied to
-- Whether the fix commit was amended (yes → mirror folded in; no → no
-  new doc content to fold)
+- Round commit SHA
+- **State:** `round_unpushed` (mid-cycle, NOT mergeable). The merge
+  transition starts from `gh_review`, which requires push.
 - **Next step for the user:** `git push` (or `git push -u origin
-  <branch>` if this is the first push for the branch)
+  <branch>` if this is the first push for the branch). Then merge
+  via `scripts/safe_merge.sh <pr-args>` rather than `gh pr merge` —
+  the wrapper refuses to invoke the merge while the local branch is
+  ahead of origin, which is the only protection against silently
+  dropping an unpushed round.
+
+**If Step 6 made no commit** (all-`ask` round or every reply was
+already a duplicate of an existing one — no code delta, no doc
+delta):
+
+- Number of threads replied to (may be zero)
+- "No commit — nothing staged after Step 5"
+- **State:** `gh_review` (no change — branch is exactly where it
+  started). Mergeable when reviewers stop posting.
+- **Next step for the user:** read the review file for any `ask`
+  threads that need their judgment.
 
 Do **not** push. The user runs the push explicitly as the last step.
 
 ---
 
-## No-op round (all push-back, no code fix)
+## Recovery: partial reply-post failure
 
-If every thread got push-back and no code changed this round, there is
-**no fix commit** to amend into. In that case:
+If `scripts/reply_review.py` fails partway through Step 4, abort the
+run before Step 5. Working tree has the code edits but no mirrored
+replies. Some replies are on GitHub, some aren't. Re-run
+`/reply-reviews`:
 
-- Step 0b sees no unpushed commits and unreplied threads → refuses,
-  per the preconditions. This is intentional: without a fix commit,
-  the only ways to land the reply-mirror are a standalone `doc:`
-  commit (wasteful) or leaving it uncommitted until the next round.
-  The latter is fine — a later round's fix commit will fold in all
-  pending doc deltas via its own `/reply-reviews`.
+1. Step 1's `pull_reviews.py` mirrors the already-posted replies into
+   the doc.
+2. Step 2's "unreplied threads" filter skips threads that now have
+   `↳ {user}` mirrored replies — only the unposted threads remain.
+3. Steps 3–5 cover the missing posts and re-mirror.
+4. Step 6 commits everything.
 
-- Recovery: post the push-back replies manually via
-  `scripts/reply_review.py` (the GitHub threads remain the canonical
-  record), and let the next substantive round's `/reply-reviews` catch
-  up the mirror.
+`reply_review.py` is **not** idempotent server-side — calling it twice
+with the same `in_reply_to_id` posts twice. Idempotency comes from
+the Step 1 mirror happening *before* Step 2's filter; don't bypass
+Step 1 on retry.
+
+## Recovery: pre-commit hook fails in Step 6
+
+Replies are on GitHub. Working tree has code edits + mirrored doc,
+all uncommitted. Fix the test/clippy/PII issue, then either:
+
+- **`git commit` manually**: same staging, same message. The
+  pre-commit hook re-runs.
+- **Re-run `/reply-reviews`**: Step 0b sees no unpushed commits, Step
+  1+2 see no unreplied threads (all already mirrored), Steps 3–5 are
+  no-ops, Step 6 retries the commit.
+
+Both paths converge on the same `round_unpushed` state.
 
 ## Notes
 
@@ -203,6 +274,6 @@ If every thread got push-back and no code changed this round, there is
   authored reply closes the thread.
 - **One reply per thread, not per comment.** If a thread already has
   a human reply, don't post another.
-- **The review file rides with the fix commit.** Never as a standalone
-  `doc: update review-NNNNN.md` commit — that was the ordering bug this
-  command eliminates.
+- **The whole round is one commit.** Never two commits per round
+  (a `fix:` then a `doc:`) — that defeats the atomicity guarantee
+  this command exists to provide.

--- a/.claude/commands/sprint-review.md
+++ b/.claude/commands/sprint-review.md
@@ -261,26 +261,88 @@ review rounds:
 {reviewer output}
 ```
 
+## Step 6: Triage and apply auto-fixable items
+
+For each item in the reviewer's **Must fix before push** and
+**Follow-up (future work)** sections, classify into exactly one
+bucket — same heuristic as `/watch-pr`:
+
+- **auto** — change is local (one file, under ~20 lines),
+  non-destructive (no API removal, no file deletion), and does not
+  require cross-module reasoning. Doc nits, missing imports, dead
+  arms, off-by-one in comments, narrow logic fixes, small test
+  additions. Apply now.
+- **needs-user** — larger scope, judgment calls, design decisions,
+  cross-module refactors, or anything where you'd hesitate.
+  **Do not apply.** Surface in the report.
+
+When in doubt, classify as **needs-user** (a miscategorized auto-fix
+ships wrong code; a miscategorized needs-user only delays one
+iteration until the user resolves it).
+
+### Apply the auto bucket
+
+Apply each auto-bucket item to the working tree. Stay strictly within
+the scope of the reviewer's comment — no adjacent cleanup, no "while
+I'm here" changes. If multiple items touch the same file, batch the
+edits before running tests.
+
+Then commit:
+
+```
+git add <edited files>
+git commit -m "<prefix>: Address sprint-review feedback"
+```
+
+Use the prefix that matches the nature of the fixes:
+`fix:` (bug), `debt:` (mechanical cleanup), `test:` (test additions),
+`doc:` (doc nits). Mix-and-match isn't possible in one commit — if
+the auto items split across categories, pick the predominant one.
+
+The pre-commit hook runs `cargo fmt --check`, `scripts/check-pii.sh`,
+`cargo test --workspace`, and `cargo clippy --all-targets -- -D
+warnings`. If it fails:
+
+- Read the failure. If a specific auto-fix caused the breakage,
+  revert that one edit, reclassify the corresponding item as
+  **needs-user**, and retry the commit.
+- If the commit still fails: leave the working tree dirty so the
+  user can investigate. Surface the failure in the report.
+
+**Do not loop `/sprint-review` recursively.** One pass of auto-fixes
+is the contract — the agent applies what it confidently can, then
+hands off. The user can re-run `/sprint-review` for another pass if
+they want one.
+
+## Step 7: Report and hand off
+
+Print a structured summary, ≤ 15 lines:
+
+```
+sprint-review for <branch>
+  must-fix items:        <total>
+    auto-applied:        <n>
+    needs you:           <m>   ← these need your decision
+      - path:line — one-line summary
+      - path:line — one-line summary
+  follow-ups (auto-applied): <n>
+  follow-ups (deferred):     <n>   ← tracked, not blocking
+  fix commit:            <sha> (or: "no commit — all needs-user")
+```
+
 Then:
 
-1. **Print a summary** to the conversation: how many must-fix items,
-   how many follow-ups, and the path to the review file. One paragraph
-   max.
+- **If zero `needs-user` items remain:** branch is clear to push.
+  Offer to push and open the PR (but don't do it without
+  confirmation):
+  ```
+  gh pr create --title "<title>" \
+    --body-file <(scripts/extract_pr_body.sh NNNNN)
+  ```
+  This makes the GitHub body a direct copy of the `## Summary`
+  section — the two can't drift. Tier 2 (CI + GitHub review) runs
+  automatically on the PR.
 
-2. **If zero must-fix items:**
-   Tell the user the branch is clear to push. Offer to push and open
-   the PR (but don't do it without confirmation). The PR-create
-   command is:
-
-   ```
-   gh pr create --title "<title>" \
-     --body-file <(scripts/extract_pr_body.sh NNNNN)
-   ```
-
-   This makes the GitHub body a direct copy of the `## Summary`
-   section — the two can't drift. Remind the user that Tier 2 (CI +
-   GitHub review) will run automatically on the PR.
-
-3. **If must-fix items exist:**
-   Stop. Do not push. Do not offer to fix the issues. The user reads
-   the review and decides what to do next.
+- **If `needs-user` items remain:** the user reads the review file
+  and decides which ones to fix, push back on, or defer. Don't push.
+  Don't auto-fix the needs-user items.

--- a/.claude/commands/watch-pr.md
+++ b/.claude/commands/watch-pr.md
@@ -1,5 +1,5 @@
 ---
-description: Poll a PR for new review comments; auto-address the trivially-clear ones, run the full /reply-reviews flow, and stop before push. Designed for /loop-driven automation (e.g., `/loop 10m /watch-pr 17`). Never pushes. Refuses if a prior round's fix commit is still unpushed.
+description: Poll a PR for new review comments; auto-address the trivially-clear ones, run the full /reply-reviews flow, and stop before push. Designed for /loop-driven automation (e.g., `/loop 10m /watch-pr 17`). Never pushes. Refuses if a prior round's commit is still unpushed (state `round_unpushed` per doc/workflow.md).
 argument-hint: <pr-number>
 ---
 
@@ -91,7 +91,7 @@ new top-level thread, classify it into exactly one bucket:
 wrong code; a miscategorized ask only delays a round by one loop tick
 until the user resolves it.
 
-## Step 3: Apply the auto-fix items
+## Step 3: Apply the auto-fix items (no commit yet)
 
 For each **auto-fix** item:
 
@@ -102,27 +102,16 @@ For each **auto-fix** item:
 3. If multiple auto-fix items touch the same file, batch the edits
    before running tests (faster feedback).
 
-Once all auto-fix edits are staged:
+**Do not commit yet.** The whole round (code fix + replies + mirrored
+doc) is committed once in Step 4 as a single atomic commit. This
+matches the FSM in `doc/workflow.md`: `items_pulled → round_unpushed`
+is a single transition; there is no intermediate `fix_unpushed` state.
 
-```
-git add <edited files>
-git commit -m "fix: Address review feedback on PR #<N>"
-```
+If no auto-fix items apply (all push-back / defer / ask), the working
+tree stays clean and Step 4's commit will be `doc:`-prefixed (mirror
+only).
 
-The pre-commit hook runs `cargo fmt --check`, `scripts/check-pii.sh`,
-`cargo test --workspace`, and `cargo clippy --all-targets -- -D
-warnings`. If it fails:
-
-- Read the failure. If it's a single fix causing the failure, revert
-  that specific edit and reclassify the corresponding thread as
-  **push-back** with an explanation of why the suggestion breaks the
-  build.
-- Retry the commit.
-- If the commit fails twice: abort the round. Revert all uncommitted
-  edits (`git checkout -- <files>`), log what went wrong, exit. The
-  user will investigate on the next loop tick.
-
-## Step 4: Complete the round (inline /reply-reviews)
+## Step 4: Post replies, mirror, and commit the round atomically
 
 For each **auto-fix**, **push-back**, and **defer** thread from Step 2,
 compose a 1–3 sentence reply per the rules in
@@ -138,33 +127,79 @@ for each thread: scripts/reply_review.py <N> <in_reply_to_id> "<body>"
 # Mirror replies back into the review doc
 scripts/pull_reviews.py <N>
 
-# Fold the doc update into the fix commit
-git add doc/reviews/review-NNNNN.md
-git commit --amend --no-edit
+# Single atomic commit: code edits (if any) + mirrored doc.
+# Conditional on having staged changes — an all-`ask` round with no
+# doc delta produces nothing to commit.
+git add -A
+if git diff --cached --quiet; then
+    # Nothing staged — branch stays at gh_review. Step 5's
+    # "no commit" report branch fires.
+    :
+else
+    # Pick prefix based on staged content:
+    #   fix:  any code edit (most common when there are auto-fixes)
+    #   doc:  only doc/reviews/<file>.md changed (replies-only round)
+    git commit -m "fix: Address review feedback on PR #<N>"
+fi
 ```
 
-The amend is safe because Step 0d confirmed the fix commit is unpushed.
+The pre-commit hook runs `cargo fmt --check`, `scripts/check-pii.sh`,
+`cargo test --workspace`, and `cargo clippy --all-targets -- -D
+warnings`. If it fails:
 
-If Step 3 made no commit (all items were push-back / defer / ask) the
-reply-post still happens, but there's no commit to amend. In that case
-leave `review-NNNNN.md` modified-but-uncommitted — the next round's fix
-commit will fold it in (matching `/pull-reviews`'s standalone-use
-contract).
+- Read the failure. If a specific auto-fix caused the breakage, revert
+  that one edit and reclassify the corresponding thread as
+  **push-back** with an explanation. Retry `git commit`.
+- If the commit fails twice: abort the round. Replies are already on
+  GitHub (Step 4's post loop is destructive); leave the working tree
+  dirty so the next loop tick exits at Step 0c and surfaces the issue
+  to the user. Do not `git checkout --` — that would discard the
+  fixes the replies reference.
+
+If `reply_review.py` fails partway through the post loop (network /
+rate limit), abort before mirror+commit. Re-running this step is
+clean: the next tick's Step 1 mirrors the already-posted replies, the
+"unreplied threads" filter skips them, and the missing posts go
+through. (Same as `/reply-reviews`'s Recovery section.)
 
 ## Step 5: Report
 
-Print a structured summary, ≤ 15 lines:
+Print a structured summary, ≤ 15 lines. The heading names the FSM
+state from `doc/workflow.md` so the read-out reflects what's actually
+true on the wire — **`round_unpushed` is mid-cycle, not mergeable**.
+Picking the right heading is load-bearing because the user reads it
+to decide whether the PR is ready to merge.
+
+If Step 4's commit succeeded (whether code+doc or doc-only):
 
 ```
-watch-pr PR #<N> — round complete
+watch-pr PR #<N> — paused at round_unpushed (commit unpushed)
   auto-fixed:  <count>   (e.g., "unused import, typo in doc")
   pushed-back: <count>   (e.g., "proposed rename conflicts with crate boundary")
   deferred:    <count>
   needs you:   <count>   ← these stay open; read them
     - path:line — one-line summary
     - path:line — one-line summary
-  fix commit:  <sha>     (or: "no commit — all push-back/defer")
-  next step:   review the commit, then `git push`
+  round commit: <sha>    (unpushed — fix: or doc:)
+  next step:   git push to advance to gh_review (mergeable).
+               DO NOT merge from round_unpushed — local commit
+               would be silently dropped. Use scripts/safe_merge.sh
+               which refuses to invoke `gh pr merge` while ahead of
+               origin.
+```
+
+If Step 4 produced no commit (no auto-fix items AND no replies
+posted — all items were `ask`):
+
+```
+watch-pr PR #<N> — round complete at gh_review (no commit needed)
+  auto-fixed:  0
+  pushed-back: 0
+  deferred:    0
+  needs you:   <count>
+    - path:line — one-line summary
+  round commit: none — all items classified as `ask`, no replies posted
+  next step:   PR is mergeable when reviewers stop posting.
 ```
 
 Do not push. Do not start another round synchronously.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,27 +189,41 @@ item and skips any id already present, so running it repeatedly only
 appends new comments. The result is one file per PR containing the full
 local + GitHub review history in order.
 
-Once the findings are addressed in a fix commit **locally (not yet
-pushed)**, run `/reply-reviews <N>`. The command does the whole round
+Once the findings are addressed as **uncommitted edits in the working
+tree**, run `/reply-reviews <N>`. The command does the whole round
 in order: posts replies to each unresolved thread, runs
 `scripts/pull_reviews.py` to mirror the replies into `review-NNNNN.md`,
-and `git commit --amend`s the mutated doc into the same fix commit. You
-then `git push` once — code + replies + review doc land in a single
-round trip.
+then makes ONE atomic commit containing both the code edits and the
+mirrored doc. You then `git push` once — code + replies + review doc
+land in a single round trip.
 
-**Do not push before running `/reply-reviews`.** The amend-into-fix-commit
-step requires the commit to be unpushed. Pushing first strands the
-mirrored replies in the working tree and forces either a wasted `doc:`
-commit (extra CI round-trip) or a force-push that this workflow is
-designed to avoid. `/reply-reviews` enforces
-this: it refuses to run if HEAD is not ahead of `origin/<branch>` while
-unreplied threads still exist.
+**Do not commit the fix yourself before running `/reply-reviews`.**
+The command runs on the `gh_review → items_pulled → round_unpushed`
+arrow per `doc/workflow.md` — it expects to start from `gh_review`
+(local at-or-behind origin) and produce the round commit itself.
+Pre-committing a fix would put the branch at an unpushed-state that
+breaks the precondition; if you have a stranded pre-existing fix
+commit, push it first, then re-run. `/reply-reviews` refuses to run
+if the branch already has unpushed commits.
+
+**Do not merge before pushing the round commit.** Per
+`doc/workflow.md`'s state machine, the merge transition is
+`gh_review → merged` — there is no edge from `round_unpushed → merged`.
+Merging from `round_unpushed` (the state after `/reply-reviews`
+makes its commit but before push) silently drops the local commit
+because `gh pr merge` is GitHub-side and doesn't see local state.
+Use `scripts/safe_merge.sh <pr-args>` instead of `gh pr merge` —
+the wrapper refuses to invoke the merge while the local branch
+is ahead of origin. Recovery (if a merge already dropped a round
+commit): cherry-pick the stranded SHA into the next plan branch's
+first commit per the bundle-into-next-plan convention; don't open
+a tiny standalone PR.
 
 `/pull-reviews <N>` remains available as a lower-level primitive for
 fetching comments without posting. Use it standalone only to refresh
 the doc right before the final pre-merge push, to capture any trailing
-reviewer comments; its output rides with the next fix commit, never as
-a standalone `doc:` commit.
+reviewer comments; its output rides with the next round commit, never
+as a standalone `doc:` commit.
 
 The local review catches design issues and convention violations early.
 The GitHub review catches anything that slipped through and validates in

--- a/doc/workflow.md
+++ b/doc/workflow.md
@@ -12,8 +12,8 @@ show up as real graphs on the PR page.
 ## Review round lifecycle
 
 One sprint from `main` through merge, covering Tier 1 (local) review,
-Tier 2 (GitHub) rounds, and the fix → reply → mirror → amend → push
-motion that `/reply-reviews` enforces.
+Tier 2 (GitHub) rounds, and the fix-edits → reply → mirror → commit →
+push motion that `/reply-reviews` enforces.
 
 ```mermaid
 stateDiagram-v2
@@ -27,21 +27,32 @@ stateDiagram-v2
     local_reviewed --> pushed: clean, git push
     pushed --> gh_review: CI runs + reviewers post
     gh_review --> items_pulled: /pull-reviews
-    items_pulled --> fix_unpushed: address items, local fix commit
-    fix_unpushed --> replies_amended: /reply-reviews (post + mirror + amend)
-    replies_amended --> gh_review: git push (code + replies + doc in one trip)
-    gh_review --> merged: no more items, rebase + ff to main
+    items_pulled --> round_unpushed: edit working tree + /reply-reviews (post + mirror + atomic commit)
+    round_unpushed --> gh_review: git push (mandatory before merge)
+    gh_review --> merged: no more items, scripts/safe_merge.sh (rebase + ff)
     merged --> [*]
 ```
 
 **Legend:**
-- `fix_unpushed` is the load-bearing state. `/reply-reviews` refuses
-  to run outside it, so the reply mirror never ends up stranded in the
-  working tree.
-- The `gh_review → items_pulled → fix_unpushed → replies_amended → gh_review`
-  cycle runs once per review round. Pushing before the amend breaks
-  the cycle — it forces either a wasted `doc:` commit (extra CI
-  round-trip) or a disallowed force-push.
+- `round_unpushed` is the load-bearing state — one atomic commit
+  containing both the code fix and the mirrored reply doc, sitting
+  unpushed on the local branch. `/reply-reviews` produces it in one
+  flow: refresh via `scripts/pull_reviews.py` → identify unreplied
+  threads → post replies via `scripts/reply_review.py` → refresh
+  again to mirror via `scripts/pull_reviews.py` → `git add -A &&
+  git commit`. There is no `--amend` step and no prior fix commit
+  to amend onto; replies and code arrive together by construction.
+- The `gh_review → items_pulled → round_unpushed → gh_review` cycle
+  runs once per review round. The transition out of `round_unpushed`
+  is `git push` — that's the only way to advance to mergeability.
+- **Never merge from `round_unpushed`.** There is no
+  `round_unpushed → merged` edge in the FSM — only `gh_review →
+  merged`. `gh pr merge` is GitHub-side and doesn't see local state,
+  so a merge with an unpushed round silently drops the local commit.
+  Use `scripts/safe_merge.sh <pr-args>` instead of `gh pr merge` —
+  it refuses to invoke the merge while the local branch is ahead of
+  origin. (Equivalent local check: `git log origin/<branch>..HEAD
+  --oneline` must be empty.)
 - `local_reviewed → impl_green` is the must-fix loop-back. The fix
   commits stay on the same branch; re-append any new Deferred/Review
   notes, then `/sprint-review` re-runs against the new tip.
@@ -52,6 +63,46 @@ stateDiagram-v2
   `## Summary`. Committing the description pre-push is what lets a
   silent PR merge without an extra round-trip — `gh pr create`
   feeds GitHub a direct copy via `scripts/extract_pr_body.sh`.
+
+**Recovery: stranded round commit after merge from `round_unpushed`.**
+
+If a merge happened while the round was at `round_unpushed` (i.e.
+`safe_merge.sh` was bypassed and `gh pr merge` was used directly) and
+the local commit got stranded, the round-2 work isn't lost — it's
+sitting on the local feature branch's tip. Don't open a tiny
+standalone PR for it; per repo convention, fold the stranded commit
+into the next plan branch's first commit:
+
+```
+# On the next plan branch, after the plan: commit:
+git cherry-pick <stranded-sha>
+# Squash into the first feat/fix commit you make on this branch,
+# OR keep as a separate `fix:` commit if the change stands alone.
+```
+
+The previously-posted GitHub replies remain accurate (they reference
+the right SHAs at the time of posting). The next PR's review file
+should reference the prior PR's `gh-id` URLs in a `### History`
+section so the chain isn't orphaned.
+
+**Recovery: partial reply-post failure mid-`/reply-reviews`.**
+
+If `scripts/reply_review.py` fails partway through the post loop
+(network, rate limit, auth), `/reply-reviews` aborts before the
+mirror+commit step. Some replies are on GitHub, some aren't; the
+working tree still has the uncommitted code edits but no mirrored
+doc changes. Recovery is a re-run of `/reply-reviews`:
+
+1. Step 1's `pull_reviews.py` mirrors the already-posted replies into
+   the doc.
+2. Step 2's "unreplied threads" filter skips threads with mirrored
+   replies — so we only post the missing ones.
+3. The rest of the run completes normally.
+
+`reply_review.py` is **not** idempotent server-side — calling it
+twice with the same `in_reply_to_id` posts twice. Idempotency comes
+from the "skip already-replied threads" filter, which depends on the
+mirror happening *before* the post loop. Don't bypass Step 1.
 
 ## `/watch-pr` dynamic-mode loop
 

--- a/scripts/safe_merge.sh
+++ b/scripts/safe_merge.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# safe_merge.sh — guard `gh pr merge` against the `round_unpushed`
+# trap.
+#
+# `doc/workflow.md`'s state machine has no edge from `round_unpushed`
+# to `merged`. The only path is `round_unpushed → push → gh_review →
+# merged`. But `gh pr merge` is a GitHub-side operation; it doesn't
+# know about local state. Merging while a round commit sits unpushed
+# on the local branch silently drops it on the floor — the merge
+# takes the remote head, and the local commit stays orphaned in the
+# reflog.
+#
+# This script is the local-side enforcement: it resolves the PR's head
+# branch (via `gh pr view`, *not* the currently-checked-out branch —
+# safe_merge.sh 17 might be invoked from main), then refuses to invoke
+# `gh pr merge` if that PR's local branch is ahead of its remote
+# tracking ref. Re-run after `git push`.
+#
+# Usage:
+#   scripts/safe_merge.sh <gh-pr-merge-args...>
+#
+# Examples:
+#   scripts/safe_merge.sh 17                      # interactive
+#   scripts/safe_merge.sh 17 --rebase --delete-branch
+#   scripts/safe_merge.sh --rebase                # current branch's open PR
+#
+# All arguments are forwarded verbatim to `gh pr merge` after the
+# guard passes.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  cat >&2 <<'USAGE'
+usage: safe_merge.sh <gh-pr-merge-args...>
+
+Resolves the PR's head branch via `gh pr view`, then refuses to run
+if that local branch is ahead of its remote tracking ref. All
+arguments are forwarded to `gh pr merge` once the guard passes.
+USAGE
+  exit 64
+fi
+
+# Resolve the PR's head ref. `gh pr view` accepts the same first-arg
+# shapes as `gh pr merge` — number, URL, branch name, or no arg
+# (defaulting to the current branch's open PR). The first arg is a
+# selector iff it doesn't start with `-`.
+if [ $# -ge 1 ] && [ "${1#-}" = "$1" ]; then
+  pr_selector=("$1")
+else
+  pr_selector=()
+fi
+
+if ! head_ref=$(gh pr view "${pr_selector[@]}" --json headRefName --jq .headRefName 2>/dev/null); then
+  echo "safe_merge.sh: failed to resolve PR head ref via 'gh pr view ${pr_selector[*]}'." >&2
+  echo "  is the PR specifier valid, and are you authenticated to gh?" >&2
+  exit 1
+fi
+if [ -z "$head_ref" ]; then
+  echo "safe_merge.sh: 'gh pr view' returned empty headRefName." >&2
+  exit 1
+fi
+
+# Refresh the remote tracking ref so the comparison isn't stale. A
+# silent failure here (offline, auth) is fine — the next check will
+# still compare against whatever's local, and the user will see if
+# something's wrong.
+git fetch --quiet origin "$head_ref" || true
+
+upstream="origin/$head_ref"
+if ! git rev-parse --verify --quiet "$upstream" >/dev/null; then
+  echo "safe_merge.sh: no remote tracking ref '$upstream'." >&2
+  echo "  push the branch first, then re-run." >&2
+  exit 1
+fi
+
+# Resolve the local copy of the PR's head ref. If the branch isn't
+# checked out anywhere, there can't be unpushed local commits — the
+# guard isn't meaningful, and the merge is safe.
+if ! local_sha=$(git rev-parse --verify --quiet "refs/heads/$head_ref"); then
+  exec gh pr merge "$@"
+fi
+
+ahead=$(git log "$upstream..$local_sha" --oneline)
+if [ -n "$ahead" ]; then
+  cat >&2 <<EOF
+safe_merge.sh: REFUSING TO MERGE — local branch '$head_ref' is ahead of $upstream.
+
+Unpushed commits would be silently dropped by the merge:
+
+$ahead
+
+Per doc/workflow.md, the merge transition starts from gh_review (push
+complete), not round_unpushed. Push first, then re-run:
+
+    git push origin $head_ref
+    $0 $*
+
+EOF
+  exit 1
+fi
+
+exec gh pr merge "$@"


### PR DESCRIPTION
Ports three workflow improvements from a downstream consumer of this template back into the template itself, so new projects spawned from template-rust pick them up by default.

## 1. Single-state pre-push round

Was:
```
gh_review → items_pulled → fix_unpushed → replies_amended → gh_review
```

The two transient pre-push states meant two opportunities for a merge to silently drop work. `gh pr merge` is a GitHub-side operation; it doesn't see local state, so a merge while a local-only commit existed would silently take the remote head and strand the unpushed commit in the reflog.

Now:
```
gh_review → items_pulled → round_unpushed → gh_review
                              ↑
        edit working tree + /reply-reviews (post + mirror + atomic commit)
```

`replies_amended` is gone. `fix_unpushed` is gone. The sole pre-push state is `round_unpushed`, a fully-formed atomic commit containing both the code fix and the mirrored reply doc — built in one shot by the new `/reply-reviews` flow. There is no `--amend` step.

## 2. `/sprint-review` autonomy

Old Step 5 ended with **"Stop. Do not push. Do not offer to fix the issues."** That gate forced the user back into the agent loop after every reviewer pass, even for items in the established `/watch-pr` auto-fix bucket (one file, <~20 lines, no API changes, no cross-module reasoning).

New Steps 6+7 triage the reviewer's must-fix and small-scope follow-up items into:
- **auto** — applied autonomously, committed as `fix:`/`debt:`/`test:`/`doc:`.
- **needs-user** — surfaced in the Step 7 report; not auto-applied.

When in doubt, classify as **needs-user**. One pass of auto-fixes; no recursion.

## 3. `scripts/safe_merge.sh` — local-side merge guard

`gh pr merge` doesn't see local state. Even with the new single-state FSM, a user bypassing the new flow (calling `gh pr merge` directly) could still strand a local commit. `safe_merge.sh` resolves the PR's head ref via `gh pr view --json headRefName`, then refuses to invoke `gh pr merge` if that local branch is ahead of its remote tracking ref. Forwards all arguments to `gh pr merge` once the guard passes. Defense-in-depth.

## Atomicity guarantee

Exactly one pre-push commit per round; either it's pushed (`gh_review`) or it isn't (`round_unpushed`). The FSM no longer has a state where a merge can desynchronize from the local round.

## Files changed

- `doc/workflow.md` — FSM diagram, legend, recovery sections rewritten.
- `.claude/commands/reply-reviews.md` — new Step ordering (fix-edits-first; atomic Step 6 commit; conditional on staged changes; no `--amend`).
- `.claude/commands/watch-pr.md` — Step 3 no longer commits; Step 4 conditional atomic commit; Step 5 report uses new state name.
- `.claude/commands/sprint-review.md` — Step 5 hand-off replaced with Steps 6 (triage + apply) + 7 (state-named report).
- `.claude/commands/pull-reviews.md` — phrasing updated.
- `CLAUDE.md` — Two-tier review section rewritten for the new flow.
- `scripts/safe_merge.sh` (new, executable) — merge guard.

## Test plan

- [x] `bash -n scripts/safe_merge.sh` syntax OK
- [x] `scripts/safe_merge.sh` no args → usage exit 64
- [x] `grep -rn 'replies_amended\|fix_unpushed' --include='*.md' --include='*.sh'` returns only intentional historical references in `/reply-reviews.md` and `/watch-pr.md`
- [ ] CI passes