### PR TITLE
Add git-side pre-commit hook (.githooks/pre-commit)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit — git-side pre-commit gate.
+#
+# Companion to the Claude Code `PreToolUse` hook in
+# `.claude/settings.json`. The two layers complement each other:
+#
+#   - `.claude/settings.json` runs DURING agent iteration, before
+#     the Bash call that invokes git fires. Catches issues without
+#     the agent needing to actually invoke git, which is faster
+#     feedback. But: it sees the staged diff at PreToolUse time,
+#     which means a chained command like `git add file && git
+#     commit -m ...` slips through — the `git add` half hasn't
+#     run yet at hook fire, so `check-pii.sh` reads an empty
+#     pre-add staged diff. Issue #8 documents this.
+#
+#   - `.githooks/pre-commit` (this file) runs at git's standard
+#     `pre-commit` hook point — AFTER staging, BEFORE the commit
+#     object is created. So it sees the actual staged content
+#     regardless of how the commit was invoked: chained `git add
+#     && git commit`, agent-invoked Bash calls that bypass the
+#     Claude Code hook, terminal commits, IDE commits, all paths.
+#
+# This file is the unbypassable safety net at commit time. Activate
+# it on a fresh clone with:
+#
+#     git config core.hooksPath .githooks
+#
+# Bypass with `--no-verify` only when explicitly authorized.
+#
+# Exit codes follow git convention: nonzero blocks the commit.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# 1. cargo fmt — warn-only, matches the documented Claude Code hook
+#    semantics. Run `cargo fmt --all` to fix any drift the warning
+#    surfaces. Flip to blocking by removing the `|| { … }` wrapper.
+if ! cargo fmt --all -- --check >/dev/null 2>&1; then
+  echo "[warn] cargo fmt found formatting differences (non-blocking; run: cargo fmt --all)" >&2
+fi
+
+# 2. PII / secret scan — blocking.
+scripts/check-pii.sh
+
+# 3. Test suite — blocking.
+cargo test --workspace --quiet
+
+# 4. Lints — blocking; matches CI.
+cargo clippy --all-targets --quiet -- -D warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,27 +294,51 @@ One slug, three places.
 10. Clean up: `git worktree remove ../<repo>.plan-YYYY-MM-DD-NN`
     (worktree case only), then `git branch -d plan/YYYY-MM-DD-NN`.
 
-### Pre-commit hook
+### Pre-commit hooks
 
-A Claude Code hook in `.claude/settings.json` runs these checks before
-every `git commit` tool call:
+Two complementary layers guard every commit:
+
+**Layer 1 — Claude Code `PreToolUse`** (`.claude/settings.json`):
+fires on agent-invoked Bash calls matching `git commit*`. Catches
+issues during agent iteration without invoking git for real.
+Limitation: `PreToolUse` runs *before* the matched Bash call's body
+executes, so a chained command like `git add file && git commit -m
+"..."` sees an empty pre-add staged diff at hook time and slips
+through `check-pii.sh`. Use separate `git add` and `git commit`
+calls to keep this layer effective.
+
+**Layer 2 — Git `pre-commit`** (`.githooks/pre-commit`): fires at
+git's standard hook point (after staging, before commit object
+creation). Sees the actual staged content regardless of how the
+commit was invoked — chained Bash, terminal, IDE, anything. This is
+the unbypassable safety net.
+
+Activate Layer 2 on a fresh clone:
+
+```
+git config core.hooksPath .githooks
+```
+
+Both layers run the same check chain, in order:
 
 1. `cargo fmt --all -- --check` — **warn-only**. Prints a diff if any
-   files need formatting but does not block the commit. CI mirrors this
-   as a `continue-on-error` step. Run `cargo fmt --all` to fix.
-2. `scripts/check-pii.sh` — grep the staged diff for absolute user-home
-   paths (`/Users/...` on macOS, `/home/...` on Linux), private-key
-   headers, and common API-token shapes. Fail fast on any match.
-   Allow-list exceptions go in `.pii-allow`.
+   files need formatting but does not block the commit. CI mirrors
+   this as a `continue-on-error` step. Run `cargo fmt --all` to fix.
+2. `scripts/check-pii.sh` — grep the staged diff for absolute
+   user-home paths (`/Users/...` on macOS, `/home/...` on Linux),
+   private-key headers, and common API-token shapes. Fail fast on
+   any match. Allow-list exceptions go in `.pii-allow`.
 3. `cargo test --workspace` — all tests must pass.
 4. `cargo clippy --all-targets -- -D warnings` — matches CI.
 
-If a blocking step fails, the commit is blocked. This is the automated
-quality gate; `/sprint-review` is the manual one.
+If a blocking step fails, the commit is blocked. This is the
+automated quality gate; `/sprint-review` is the manual one. Bypass
+with `--no-verify` only when explicitly authorized.
 
 CI adds a `gitleaks` job (`.github/workflows/ci.yml`) that scans the
 full history on every PR as defense-in-depth against anything that
-bypasses the local hook (e.g. `git commit --no-verify`).
+bypasses both local hooks (e.g. `git commit --no-verify`, or a
+clone where `core.hooksPath` was never set).
 
 ## Sprint plan format
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ is the human-facing tour.
 - **Pinned toolchain** via `rust-toolchain.toml` (Rust 1.85 + clippy +
   rustfmt). CI installs the same channel via
   `dtolnay/rust-toolchain@1.85.0`.
-- **Pre-commit hook** (`.claude/settings.json`) runs `cargo fmt --check`
-  (warn-only), a PII scan, `cargo test`, and `cargo clippy`. Blocks on
-  any real failure; `fmt` drift is a nag, not a blocker.
+- **Two-layer pre-commit hook**: a Claude Code `PreToolUse` hook
+  (`.claude/settings.json`) gates agent-invoked `git commit*` Bash
+  calls, plus a git-side `pre-commit` script (`.githooks/pre-commit`)
+  that catches commits from any path (chained Bash, terminal, IDE).
+  Both run `cargo fmt --check` (warn-only), a PII scan, `cargo test`,
+  and `cargo clippy`. Activate the git-side layer on a fresh clone:
+  `git config core.hooksPath .githooks`.
 - **CI jobs**: `test` (test + clippy + fmt warn), `deny` (cargo-deny
   licenses/advisories/sources), `secrets` (gitleaks on full history).
 - **Two-tier review**: `/sprint-review` runs an independent reviewer
@@ -107,6 +111,10 @@ scripts/
    - Set `.github/CODEOWNERS` to your GitHub handle (currently `@cmk`).
    - Clear `doc/reviews/` of everything except `review-00000.md`
      (the protected sentinel; see its contents for why).
+   - Activate the git-side pre-commit hook:
+     `git config core.hooksPath .githooks`. (Layer 1 in
+     `.claude/settings.json` works without any setup; this enables
+     Layer 2, the unbypassable safety net at commit time.)
 2. Read [CLAUDE.md](CLAUDE.md) top-to-bottom once — it's the source of
    truth for the TDD + review workflow. This README is a derived view.
 3. Start a sprint: pick a plan number, ask worktree-or-branch, write


### PR DESCRIPTION
Closes #8.

The Claude Code `PreToolUse` hook fires *before* the matched Bash call's body executes, so a chained command like `git add file && git commit -m "..."` slips through `check-pii.sh` — at hook time the chain's `git add` half hasn't run, so the staged diff is empty pre-add and the PII scan returns clean.

This PR adds a real git-side `pre-commit` hook activated via `git config core.hooksPath .githooks`. Git's `pre-commit` fires *after* staging but *before* the commit object is created, so it sees the actual staged content regardless of how the commit was invoked.

## Layered design

| Layer | Path | Fires on | Bypass risk |
|---|---|---|---|
| 1 (Claude Code) | `.claude/settings.json` `PreToolUse` | agent-invoked Bash matching `git commit*` | chained `git add && git commit`, terminal commits, IDE commits |
| 2 (git) | `.githooks/pre-commit` | every commit, regardless of source | `--no-verify` only |

Layer 1 stays for fast feedback during agent iteration (no need to invoke git). Layer 2 is the unbypassable safety net at commit time.

Both run the same chain in the same order:
1. `cargo fmt --all -- --check` — warn-only.
2. `scripts/check-pii.sh` — blocking.
3. `cargo test --workspace --quiet` — blocking.
4. `cargo clippy --all-targets --quiet -- -D warnings` — blocking.

## Bootstrap

One-time per clone:

```
git config core.hooksPath .githooks
```

Documented in:
- `README.md` "Using this template" — added as a setup bullet.
- `CLAUDE.md` "Pre-commit hooks" section — full two-layer explanation.

## End-to-end test

This commit was made with `core.hooksPath` already pointing at `.githooks`, so the new hook ran on the commit that adds it. cargo fmt warn pass-through, check-pii clean, cargo test ok, cargo clippy clean.

## Test plan

- [x] `bash -n .githooks/pre-commit` syntax OK
- [x] `git config core.hooksPath .githooks && git commit` runs the new hook end-to-end
- [x] CLAUDE.md and README.md updated to document the bootstrap step
- [ ] CI passes