### PR TITLE
Make cargo fmt --check pre-commit step blocking on both layers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{ cargo fmt --all -- --check || echo '[warn] cargo fmt found formatting differences (non-blocking; run: cargo fmt --all)'; } && scripts/check-pii.sh && cargo test --workspace --quiet 2>&1 && cargo clippy --all-targets --quiet -- -D warnings 2>&1"
+            "command": "cargo fmt --all -- --check && scripts/check-pii.sh && cargo test --workspace --quiet 2>&1 && cargo clippy --all-targets --quiet -- -D warnings 2>&1"
           }
         ]
       }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,12 +34,9 @@ set -euo pipefail
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
-# 1. cargo fmt — warn-only, matches the documented Claude Code hook
-#    semantics. Run `cargo fmt --all` to fix any drift the warning
-#    surfaces. Flip to blocking by removing the `|| { … }` wrapper.
-if ! cargo fmt --all -- --check >/dev/null 2>&1; then
-  echo "[warn] cargo fmt found formatting differences (non-blocking; run: cargo fmt --all)" >&2
-fi
+# 1. cargo fmt — blocking. Drift aborts the commit. Run
+#    `cargo fmt --all` to fix.
+cargo fmt --all -- --check
 
 # 2. PII / secret scan — blocking.
 scripts/check-pii.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,11 +333,15 @@ Activate Layer 2 on a fresh clone:
 git config core.hooksPath .githooks
 ```
 
-Both layers run the same check chain, in order:
+Both layers run the same check chain, in order. Every step is
+blocking — the chain short-circuits on the first failure and the
+commit is aborted:
 
-1. `cargo fmt --all -- --check` — **warn-only**. Prints a diff if any
-   files need formatting but does not block the commit. CI mirrors
-   this as a `continue-on-error` step. Run `cargo fmt --all` to fix.
+1. `cargo fmt --all -- --check` — fmt drift aborts the commit. Run
+   `cargo fmt --all` to fix. (Was warn-only previously; flipped to
+   blocking after a real CI fmt failure that local tooling let
+   through. Keeping the fmt step blocking forces drift to be fixed
+   at commit time rather than papered over with a warning.)
 2. `scripts/check-pii.sh` — grep the staged diff for absolute
    user-home paths (`/Users/...` on macOS, `/home/...` on Linux),
    private-key headers, and common API-token shapes. Fail fast on
@@ -345,9 +349,8 @@ Both layers run the same check chain, in order:
 3. `cargo test --workspace` — all tests must pass.
 4. `cargo clippy --all-targets -- -D warnings` — matches CI.
 
-If a blocking step fails, the commit is blocked. This is the
-automated quality gate; `/sprint-review` is the manual one. Bypass
-with `--no-verify` only when explicitly authorized.
+This is the automated quality gate; `/sprint-review` is the manual
+one. Bypass with `--no-verify` only when explicitly authorized.
 
 CI adds a `gitleaks` job (`.github/workflows/ci.yml`) that scans the
 full history on every PR as defense-in-depth against anything that

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ is the human-facing tour.
   (`.claude/settings.json`) gates agent-invoked `git commit*` Bash
   calls, plus a git-side `pre-commit` script (`.githooks/pre-commit`)
   that catches commits from any path (chained Bash, terminal, IDE).
-  Both run `cargo fmt --check` (warn-only), a PII scan, `cargo test`,
-  and `cargo clippy`. Activate the git-side layer on a fresh clone:
-  `git config core.hooksPath .githooks`.
+  Both run `cargo fmt --check`, a PII scan, `cargo test`, and
+  `cargo clippy` — every step blocking. Activate the git-side layer
+  on a fresh clone: `git config core.hooksPath .githooks`.
 - **CI jobs**: `test` (test + clippy + fmt warn), `deny` (cargo-deny
   licenses/advisories/sources), `secrets` (gitleaks on full history).
 - **Two-tier review**: `/sprint-review` runs an independent reviewer


### PR DESCRIPTION
**Stacked on #10** (`task/git-pre-commit-hook`). Merge #10 first, then GitHub will retarget this PR's base to `main`.

Drops the warn-only wrapper around `cargo fmt --all -- --check` in both pre-commit layers so fmt drift aborts the commit instead of logging a warning and proceeding.

## Diff

| Layer | File | Was | Now |
|---|---|---|---|
| 1 | `.claude/settings.json` | `{ cargo fmt … --check \|\| echo '[warn] …'; } && …` | `cargo fmt … --check && …` |
| 2 | `.githooks/pre-commit` | `if ! cargo fmt … --check; then echo '[warn] …'; fi` | `cargo fmt --all -- --check` |

`CLAUDE.md` and `README.md` updated to drop the "warn-only" framing.

## Why

A real CI fmt failure recently slipped through local tooling in a sibling project — the warn-only wrapper noticed the drift but let the commit proceed; CI then rejected it on push, costing an extra round-trip. Keeping the fmt step blocking forces drift to be fixed at commit time when the cost is low (one `cargo fmt --all` invocation).

The CI fmt step is `continue-on-error` for historical reasons, but with the local hook now blocking, a fmt-drift commit can't even reach CI without the user explicitly using `--no-verify`. Symmetric strictness across both layers.

## Test plan

- [x] `bash -n .githooks/pre-commit` syntax OK
- [x] commit on this branch succeeded — both layers ran cleanly with no fmt drift
- [x] Inject fmt drift, verify commit aborts on both layers
- [x] CI passes