### PR TITLE
Backport workflow review fixes

### DIFF
--- a/.claude/commands/reply-reviews.md
+++ b/.claude/commands/reply-reviews.md
@@ -178,9 +178,14 @@ if git diff --cached --quiet; then
     :
 else
     # Pick the prefix that matches the staged content:
-    #   fix:  any code edit (most common)
+    #   fix:  any staged change outside doc/reviews/*.md
     #   doc:  only doc/reviews/<file>.md changed (replies-only round)
-    git commit -m "fix: Address review feedback on PR #<N>"
+    if git diff --cached --name-only | grep -qv '^doc/reviews/.*\.md$'; then
+        prefix=fix
+    else
+        prefix=doc
+    fi
+    git commit -m "$prefix: Address review feedback on PR #<N>"
 fi
 ```
 

--- a/.claude/commands/watch-pr.md
+++ b/.claude/commands/watch-pr.md
@@ -148,9 +148,14 @@ if git diff --cached --quiet; then
     :
 else
     # Pick prefix based on staged content:
-    #   fix:  any code edit (most common when there are auto-fixes)
+    #   fix:  any staged change outside doc/reviews/*.md
     #   doc:  only doc/reviews/<file>.md changed (replies-only round)
-    git commit -m "fix: Address review feedback on PR #<N>"
+    if git diff --cached --name-only | grep -Eqv '^doc/reviews/.*\.md$'; then
+        commit_prefix=fix
+    else
+        commit_prefix=doc
+    fi
+    git commit -m "$commit_prefix: Address review feedback on PR #<N>"
 fi
 ```
 

--- a/doc/workflow.md
+++ b/doc/workflow.md
@@ -29,7 +29,7 @@ stateDiagram-v2
     gh_review --> items_pulled: /pull-reviews
     items_pulled --> round_unpushed: edit working tree + /reply-reviews (post + mirror + atomic commit)
     round_unpushed --> gh_review: git push (mandatory before merge)
-    gh_review --> merged: no more items, scripts/safe_merge.sh (rebase + ff)
+    gh_review --> merged: no more items, scripts/safe_merge.sh (after push check)
     merged --> [*]
 ```
 

--- a/doc/workflow.md
+++ b/doc/workflow.md
@@ -26,7 +26,7 @@ stateDiagram-v2
     local_reviewed --> impl_green: must-fix items surfaced
     local_reviewed --> pushed: clean, git push
     pushed --> gh_review: CI runs + reviewers post
-    gh_review --> items_pulled: /pull-reviews
+    gh_review --> items_pulled: /pull-reviews (scripts/pull_reviews.py)
     items_pulled --> round_unpushed: edit working tree + /reply-reviews (post + mirror + atomic commit)
     round_unpushed --> gh_review: git push (mandatory before merge)
     gh_review --> merged: no more items, scripts/safe_merge.sh (after push check)

--- a/scripts/local_review.sh
+++ b/scripts/local_review.sh
@@ -9,6 +9,8 @@ cd "$repo_root"
 if [ "${1:-}" = "--check" ]; then
   command -v codex >/dev/null
   codex review --help >/dev/null
+  command -v gh >/dev/null
+  scripts/review_path.sh >/dev/null
   scripts/workflow_state.sh
   exit 0
 fi

--- a/scripts/safe_merge.sh
+++ b/scripts/safe_merge.sh
@@ -91,10 +91,11 @@ $ahead
 Per doc/workflow.md, the merge transition starts from gh_review (push
 complete), not round_unpushed. Push first, then re-run:
 
-    git push origin $head_ref
-    $0 $*
-
 EOF
+  printf '    git push origin %q\n' "$head_ref" >&2
+  printf '    %q' "$0" >&2
+  printf ' %q' "$@" >&2
+  printf '\n\n' >&2
   exit 1
 fi
 

--- a/scripts/safe_merge.sh
+++ b/scripts/safe_merge.sh
@@ -17,7 +17,7 @@
 # tracking ref. Re-run after `git push`.
 #
 # Usage:
-#   scripts/safe_merge.sh <gh-pr-merge-args...>
+#   scripts/safe_merge.sh [<gh-pr-merge-args...>]
 #
 # Examples:
 #   scripts/safe_merge.sh 17                      # interactive
@@ -28,15 +28,15 @@
 # guard passes.
 set -euo pipefail
 
-if [ $# -lt 1 ]; then
+if [ $# -eq 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ]; }; then
   cat >&2 <<'USAGE'
-usage: safe_merge.sh <gh-pr-merge-args...>
+usage: safe_merge.sh [<gh-pr-merge-args...>]
 
 Resolves the PR's head branch via `gh pr view`, then refuses to run
 if that local branch is ahead of its remote tracking ref. All
 arguments are forwarded to `gh pr merge` once the guard passes.
 USAGE
-  exit 64
+  exit 0
 fi
 
 # Resolve the PR's head ref. `gh pr view` accepts the same first-arg

--- a/scripts/workflow_state.sh
+++ b/scripts/workflow_state.sh
@@ -9,7 +9,10 @@ cd "$repo_root"
 branch=$(git branch --show-current)
 status=$(git status --porcelain)
 base_commits=$(git rev-list --count origin/main..HEAD 2>/dev/null || printf 'unknown')
-pr_number=$(gh pr view --json number --jq .number 2>/dev/null || true)
+pr_number=''
+if command -v gh >/dev/null 2>&1; then
+  pr_number=$(gh pr view --json number --jq .number 2>/dev/null || true)
+fi
 
 ahead='unknown'
 behind='unknown'
@@ -22,7 +25,7 @@ review_file=''
 if [ -n "$pr_number" ]; then
   review_file=$(scripts/review_path.sh "$pr_number")
 elif [ -n "${WORKFLOW_REVIEW_FILE:-}" ]; then
-  review_file=$WORKFLOW_REVIEW_FILE
+  review_file="$WORKFLOW_REVIEW_FILE"
 fi
 
 review_summary='unknown'
@@ -47,10 +50,12 @@ fi
 
 state='unknown'
 if [ "$branch" = 'main' ]; then
-  if [ -z "$status" ]; then
-    state='main_clean'
-  else
+  if [ -n "$status" ]; then
     state='main_dirty'
+  elif [ "$ahead" != 'unknown' ] && [ "$ahead" -gt 0 ]; then
+    state='main_unpushed'
+  else
+    state='main_clean'
   fi
 elif [ -n "$status" ]; then
   state='working_tree_dirty'
@@ -58,6 +63,8 @@ elif [ "$ahead" != 'unknown' ] && [ "$ahead" -gt 0 ]; then
   state='round_unpushed'
 elif [ -n "$pr_number" ]; then
   state='gh_review'
+elif [ "$ahead" = '0' ] && [ "$behind" = '0' ] && [ "$local_review" = 'present' ]; then
+  state='pushed'
 elif [ "$local_review" = 'present' ]; then
   state='local_reviewed'
 elif [ "$review_summary" = 'present' ]; then


### PR DESCRIPTION
## Summary

- Backport review-round command fixes from downstream ports so replies-only rounds use `doc:` commits and code rounds use `fix:` commits.
- Harden workflow helper scripts: safer `safe_merge.sh` no-arg/help behavior, quoted rerun suggestions, better `workflow_state.sh` state detection, and `local_review.sh --check` prerequisite validation.
- Clarify the workflow diagram with the shell equivalent for `/pull-reviews` and the actual `safe_merge.sh` responsibility.

## Validation

- `bash -n scripts/safe_merge.sh`
- `bash -n scripts/workflow_state.sh scripts/local_review.sh scripts/safe_merge.sh`
- `git diff --check`
- `scripts/safe_merge.sh --help`
- `scripts/workflow_state.sh`
- `scripts/local_review.sh --check`
- pre-commit hook during commit