### PR TITLE
Patch workflow FSM follow-ups

### DIFF
--- a/.claude/commands/watch-pr.md
+++ b/.claude/commands/watch-pr.md
@@ -138,24 +138,28 @@ for each thread: scripts/reply_review.py <N> <in_reply_to_id> "<body>"
 # Mirror replies back into the review doc
 scripts/pull_reviews.py <N>
 
-# Single atomic commit: code edits (if any) + mirrored doc.
-# Conditional on having staged changes — an all-`ask` round with no
-# doc delta produces nothing to commit.
-git add -A
-if git diff --cached --quiet; then
-    # Nothing staged — branch stays at gh_review. Step 5's
-    # "no commit" report branch fires.
+# Single atomic commit: code edits (if any) + mirrored replies.
+# If every new item was `ask`, do not stage the pull-only review doc
+# delta from Step 1; leave it for a later substantive round.
+if [ "$auto_fix_count" -eq 0 ] && [ "$reply_count" -eq 0 ]; then
     :
 else
-    # Pick prefix based on staged content:
-    #   fix:  any staged change outside doc/reviews/*.md
-    #   doc:  only doc/reviews/<file>.md changed (replies-only round)
-    if git diff --cached --name-only | grep -Eqv '^doc/reviews/.*\.md$'; then
-        commit_prefix=fix
+    git add -A
+    if git diff --cached --quiet; then
+        # Nothing staged — branch stays at gh_review. Step 5's
+        # "no commit" report branch fires.
+        :
     else
-        commit_prefix=doc
+        # Pick prefix based on staged content:
+        #   fix:  any staged change outside doc/reviews/*.md
+        #   doc:  only doc/reviews/<file>.md changed (replies-only round)
+        if git diff --cached --name-only | grep -Eqv '^doc/reviews/.*\.md$'; then
+            commit_prefix=fix
+        else
+            commit_prefix=doc
+        fi
+        git commit -m "$commit_prefix: Address review feedback on PR #<N>"
     fi
-    git commit -m "$commit_prefix: Address review feedback on PR #<N>"
 fi
 ```
 

--- a/.claude/commands/watch-pr.md
+++ b/.claude/commands/watch-pr.md
@@ -102,6 +102,13 @@ new top-level thread, classify it into exactly one bucket:
 wrong code; a miscategorized ask only delays a round by one loop tick
 until the user resolves it.
 
+Track two counters for the commit step:
+
+```
+auto_fix_count=<number of auto-fix threads>
+reply_count=<number of auto-fix + push-back + defer threads that will receive replies>
+```
+
 ## Step 3: Apply the auto-fix items (no commit yet)
 
 For each **auto-fix** item:

--- a/scripts/local_review.sh
+++ b/scripts/local_review.sh
@@ -48,17 +48,6 @@ if ! grep -q '^## Summary[[:space:]]*$' "$review_file"; then
   exit 1
 fi
 
-plan_context=''
-latest_plan=$(ls -t doc/plans/plan-*.md 2>/dev/null | head -1 || true)
-if [ -n "$latest_plan" ]; then
-  plan_context=$(printf '\n## Sprint plan candidate: %s\n\n' "$latest_plan"; cat "$latest_plan")
-fi
-
-calibration_context=''
-if [ -f doc/reviews/review-calibration.md ]; then
-  calibration_context=$(printf '\n## Review calibration examples\n\n'; cat doc/reviews/review-calibration.md)
-fi
-
 branch=$(git branch --show-current)
 commits=$(git rev-list --count origin/main..HEAD)
 date=$(date +%F)

--- a/scripts/local_review.sh
+++ b/scripts/local_review.sh
@@ -66,23 +66,10 @@ date=$(date +%F)
 tmp=$(mktemp)
 trap 'rm -f "$tmp"' EXIT
 
-{
-  cat <<'EOF'
-You are reviewing code on a local feature branch before it is pushed to
-GitHub. This is a pre-push quality gate. Review the diff between
-origin/main and the branch HEAD.
-
-Be direct and specific. Prioritize bugs, behavioral regressions,
-missing tests, and violations of repo workflow. Cite file paths and
-line numbers where possible. Separate must-fix issues from follow-ups.
-
-Use the repo conventions and calibration examples below as context.
-EOF
-  printf '\n## Repo conventions\n\n'
-  cat AGENTS.md
-  printf '%s\n' "$plan_context"
-  printf '%s\n' "$calibration_context"
-} | codex review --base origin/main - >"$tmp"
+# Codex CLI 0.125 rejects a custom prompt together with --base, even
+# though help advertises both. AGENTS.md is discovered from the repo
+# root, so use the supported base-review invocation.
+codex review --base origin/main >"$tmp"
 
 {
   printf '\n## Local review (%s)\n\n' "$date"

--- a/scripts/safe_merge.sh
+++ b/scripts/safe_merge.sh
@@ -41,8 +41,19 @@ fi
 
 # Resolve the PR's head ref. `gh pr view` accepts the same first-arg
 # shapes as `gh pr merge` — number, URL, branch name, or no arg
-# (defaulting to the current branch's open PR). The first arg is a
-# selector iff it doesn't start with `-`.
+# (defaulting to the current branch's open PR). To keep the guard and
+# forwarded merge command checking the same PR, require any explicit
+# selector to come before flags.
+if [ $# -ge 1 ] && [ "${1#-}" != "$1" ]; then
+  for arg in "$@"; do
+    if [ "${arg#-}" = "$arg" ]; then
+      echo "safe_merge.sh: PR selector must come before merge flags: $arg" >&2
+      echo "  usage: scripts/safe_merge.sh [<pr>] [<gh-pr-merge-flags...>]" >&2
+      exit 1
+    fi
+  done
+fi
+
 if [ $# -ge 1 ] && [ "${1#-}" = "$1" ]; then
   pr_selector=("$1")
 else

--- a/scripts/safe_merge.sh
+++ b/scripts/safe_merge.sh
@@ -45,23 +45,41 @@ fi
 # forwarded merge command checking the same PR, require any explicit
 # selector to come before flags.
 if [ $# -ge 1 ] && [ "${1#-}" != "$1" ]; then
+  previous_takes_value=false
   for arg in "$@"; do
-    if [ "${arg#-}" = "$arg" ]; then
+    if [ "$previous_takes_value" = true ]; then
+      previous_takes_value=false
+    elif [ "${arg#-}" = "$arg" ]; then
       echo "safe_merge.sh: PR selector must come before merge flags: $arg" >&2
       echo "  usage: scripts/safe_merge.sh [<pr>] [<gh-pr-merge-flags...>]" >&2
       exit 1
+    else
+      case "$arg" in
+        -A|--author-email|-b|--body|-F|--body-file|--match-head-commit|-t|--subject|-R|--repo)
+          previous_takes_value=true
+          ;;
+      esac
     fi
   done
 fi
 
+declare -a pr_selector
+pr_selector_text=''
 if [ $# -ge 1 ] && [ "${1#-}" = "$1" ]; then
   pr_selector=("$1")
+  pr_selector_text="$1"
 else
   pr_selector=()
 fi
 
-if ! head_ref=$(gh pr view "${pr_selector[@]}" --json headRefName --jq .headRefName 2>/dev/null); then
-  echo "safe_merge.sh: failed to resolve PR head ref via 'gh pr view ${pr_selector[*]}'." >&2
+if [ ${#pr_selector[@]} -gt 0 ]; then
+  head_ref_cmd=(gh pr view "${pr_selector[@]}" --json headRefName --jq .headRefName)
+else
+  head_ref_cmd=(gh pr view --json headRefName --jq .headRefName)
+fi
+
+if ! head_ref=$("${head_ref_cmd[@]}" 2>/dev/null); then
+  echo "safe_merge.sh: failed to resolve PR head ref via 'gh pr view $pr_selector_text'." >&2
   echo "  is the PR specifier valid, and are you authenticated to gh?" >&2
   exit 1
 fi

--- a/scripts/workflow_state.sh
+++ b/scripts/workflow_state.sh
@@ -26,6 +26,8 @@ if [ -n "$pr_number" ]; then
   review_file=$(scripts/review_path.sh "$pr_number")
 elif [ -n "${WORKFLOW_REVIEW_FILE:-}" ]; then
   review_file="$WORKFLOW_REVIEW_FILE"
+else
+  review_file=$(scripts/review_path.sh 2>/dev/null || true)
 fi
 
 review_summary='unknown'
@@ -75,15 +77,18 @@ elif [ "$base_commits" != 'unknown' ] && [ "$base_commits" -gt 0 ]; then
   state='impl_green'
 fi
 
-cat <<EOF
-state: $state
-branch: $branch
-origin_main_commits: $base_commits
-origin_branch_ahead: $ahead
-origin_branch_behind: $behind
-working_tree: $(if [ -z "$status" ]; then printf clean; else printf dirty; fi)
-pr_number: ${pr_number:-none}
-review_file: ${review_file:-unknown}
-review_summary: $review_summary
-local_review: $local_review
-EOF
+working_tree=dirty
+if [ -z "$status" ]; then
+  working_tree=clean
+fi
+
+printf 'state: %s\n' "$state"
+printf 'branch: %s\n' "$branch"
+printf 'origin_main_commits: %s\n' "$base_commits"
+printf 'origin_branch_ahead: %s\n' "$ahead"
+printf 'origin_branch_behind: %s\n' "$behind"
+printf 'working_tree: %s\n' "$working_tree"
+printf 'pr_number: %s\n' "${pr_number:-none}"
+printf 'review_file: %s\n' "${review_file:-unknown}"
+printf 'review_summary: %s\n' "$review_summary"
+printf 'local_review: %s\n' "$local_review"


### PR DESCRIPTION
Patch workflow bugs found while porting the multi-agent workflow downstream.

Changes:
- Use the supported `codex review --base origin/main` invocation in `scripts/local_review.sh`.
- Have `scripts/workflow_state.sh` inspect the predicted review file before a PR exists, and avoid heredoc output so read-only review sandboxes can run it.
- Make `scripts/safe_merge.sh` reject flags-before-selector invocations so the guarded PR and merged PR cannot diverge.
- Update `/watch-pr` docs so all-ask ticks do not stage and push pull-only review-doc deltas.

Validation:
- `bash -n scripts/local_review.sh scripts/workflow_state.sh scripts/safe_merge.sh .githooks/pre-commit scripts/extract_pr_body.sh scripts/next_pr_number.sh scripts/check-pii.sh`
- `git diff --check`
- `scripts/safe_merge.sh --rebase 17` refusal path
- `scripts/workflow_state.sh`
- `scripts/local_review.sh --check`
- pre-commit hook on commit
