### PR TITLE
fix: Backport downstream workflow review fixes

### DIFF
--- a/.claude/commands/watch-pr.md
+++ b/.claude/commands/watch-pr.md
@@ -105,8 +105,16 @@ until the user resolves it.
 Track two counters for the commit step:
 
 ```
-auto_fix_count=<number of auto-fix threads>
-reply_count=<number of auto-fix + push-back + defer threads that will receive replies>
+auto_fix_count=0
+reply_count=0
+
+# Increment as integers while classifying threads:
+# auto-fix thread:
+auto_fix_count=$((auto_fix_count + 1))
+reply_count=$((reply_count + 1))
+
+# push-back or defer thread:
+reply_count=$((reply_count + 1))
 ```
 
 ## Step 3: Apply the auto-fix items (no commit yet)
@@ -146,10 +154,11 @@ for each thread: scripts/reply_review.py <N> <in_reply_to_id> "<body>"
 scripts/pull_reviews.py <N>
 
 # Single atomic commit: code edits (if any) + mirrored replies.
-# If every new item was `ask`, do not stage the pull-only review doc
-# delta from Step 1; leave it for a later substantive round.
+# If every new item was `ask`, do not stage or keep the pull-only
+# review-doc delta from Step 1; restore doc/reviews/ so the next tick
+# still starts from a clean tree.
 if [ "$auto_fix_count" -eq 0 ] && [ "$reply_count" -eq 0 ]; then
-    :
+    git restore --source=HEAD --worktree -- doc/reviews
 else
     git add -A
     if git diff --cached --quiet; then

--- a/scripts/safe_merge.sh
+++ b/scripts/safe_merge.sh
@@ -28,6 +28,11 @@
 # guard passes.
 set -euo pipefail
 
+if ! command -v gh >/dev/null 2>&1; then
+  echo "safe_merge.sh: gh CLI not found on PATH. Install GitHub CLI and authenticate before merging." >&2
+  exit 1
+fi
+
 if [ $# -eq 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ]; }; then
   cat >&2 <<'USAGE'
 usage: safe_merge.sh [<gh-pr-merge-args...>]
@@ -63,6 +68,26 @@ if [ $# -ge 1 ] && [ "${1#-}" != "$1" ]; then
   done
 fi
 
+declare -a repo_args
+repo_args=()
+expect_repo_value=false
+for arg in "$@"; do
+  if [ "$expect_repo_value" = true ]; then
+    repo_args+=("$arg")
+    expect_repo_value=false
+    continue
+  fi
+  case "$arg" in
+    -R|--repo)
+      repo_args+=("$arg")
+      expect_repo_value=true
+      ;;
+    --repo=*)
+      repo_args+=("$arg")
+      ;;
+  esac
+done
+
 declare -a pr_selector
 pr_selector_text=''
 if [ $# -ge 1 ] && [ "${1#-}" = "$1" ]; then
@@ -73,9 +98,9 @@ else
 fi
 
 if [ ${#pr_selector[@]} -gt 0 ]; then
-  head_ref_cmd=(gh pr view "${pr_selector[@]}" --json headRefName --jq .headRefName)
+  head_ref_cmd=(gh pr view "${pr_selector[@]}" "${repo_args[@]}" --json headRefName --jq .headRefName)
 else
-  head_ref_cmd=(gh pr view --json headRefName --jq .headRefName)
+  head_ref_cmd=(gh pr view "${repo_args[@]}" --json headRefName --jq .headRefName)
 fi
 
 if ! head_ref=$("${head_ref_cmd[@]}" 2>/dev/null); then

--- a/scripts/workflow_state.sh
+++ b/scripts/workflow_state.sh
@@ -26,7 +26,9 @@ if [ -n "$pr_number" ]; then
   review_file=$(scripts/review_path.sh "$pr_number")
 elif [ -n "${WORKFLOW_REVIEW_FILE:-}" ]; then
   review_file="$WORKFLOW_REVIEW_FILE"
-else
+elif [ "${WORKFLOW_STATE_ALLOW_REVIEW_PATH_FALLBACK:-0}" = '1' ]; then
+  # Opt-in only: the no-arg fallback may consult GitHub to predict the
+  # next PR number, which is too expensive for the default quick probe.
   review_file=$(scripts/review_path.sh 2>/dev/null || true)
 fi
 


### PR DESCRIPTION
## Summary

Backports the workflow fixes that were reviewed and landed downstream in agogo and stdio-core.

Changes:
- make safe_merge.sh fail clearly when gh is missing
- pass -R/--repo repo-selection flags through the guarded gh pr view path before merge
- gate the expensive no-arg review-path fallback in workflow_state.sh behind WORKFLOW_STATE_ALLOW_REVIEW_PATH_FALLBACK=1
- make /watch-pr counter handling copy/paste-safe and restore pull-only review docs in all-ask rounds

## Validation

- bash -n scripts/safe_merge.sh scripts/workflow_state.sh scripts/review_path.sh .githooks/pre-commit
- git diff --check
- scripts/safe_merge.sh --help
- scripts/safe_merge.sh --rebase 17 verified the expected selector-order refusal path
- commit hook passed