### PR TITLE
[codex] Improve PR script gh diagnostics

### DIFF
--- a/scripts/pr_request.sh
+++ b/scripts/pr_request.sh
@@ -27,19 +27,32 @@
 # go to stderr.
 set -euo pipefail
 
+repo_err=''
+api_err=''
+trap 'rm -f "${repo_err:-}" "${api_err:-}"' EXIT
+
+if ! command -v gh >/dev/null; then
+  echo "error: gh CLI not found on PATH" >&2
+  exit 1
+fi
+
 if [ $# -ge 1 ] && [ -n "$1" ]; then
   repo="$1"
 else
-  if ! repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null); then
+  repo_err=$(mktemp)
+  if ! repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>"$repo_err"); then
     echo "error: could not determine repo; pass owner/name or run inside a gh-configured clone" >&2
+    sed 's/^/  gh: /' "$repo_err" >&2
     exit 1
   fi
 fi
 
+api_err=$(mktemp)
 if ! last=$(gh api -X GET "repos/$repo/issues" \
     -f state=all -f per_page=1 -f sort=created -f direction=desc \
-    --jq '.[0].number // 0' 2>/dev/null); then
+    --jq '.[0].number // 0' 2>"$api_err"); then
   echo "error: gh api failed for repos/$repo/issues (check auth and network)" >&2
+  sed 's/^/  gh: /' "$api_err" >&2
   exit 1
 fi
 

--- a/scripts/pr_review.sh
+++ b/scripts/pr_review.sh
@@ -20,6 +20,11 @@ if ! command -v codex >/dev/null; then
   exit 1
 fi
 
+if ! command -v gh >/dev/null; then
+  echo "error: gh CLI not found on PATH" >&2
+  exit 1
+fi
+
 git fetch --quiet origin main
 
 if [ -n "$(git status --porcelain)" ]; then
@@ -36,7 +41,11 @@ if git diff --quiet origin/main...HEAD; then
   exit 1
 fi
 
-review_file=$(scripts/pr_report.py path)
+if ! review_file=$(scripts/pr_report.py path); then
+  echo "error: could not determine review file path" >&2
+  echo "  ensure gh is authenticated, or run scripts/pr_request.sh owner/name to diagnose GitHub access." >&2
+  exit 1
+fi
 if [ ! -f "$review_file" ]; then
   echo "error: review file not found: $review_file" >&2
   echo "  run TDD step 7 first: finalize the plan and draft PR description." >&2


### PR DESCRIPTION
## Summary

- preflight `gh` in `scripts/pr_review.sh` before predicting the review file path
- wrap review path prediction failures with a targeted diagnostic
- preserve underlying `gh repo view` and `gh api` stderr in `scripts/pr_request.sh`

## Why

The workflow scripts previously hid useful GitHub CLI/auth/network errors in the same paths that downstream repos now use for local review setup. Keeping the diagnostic hardening in `template-rust` makes the source workflow easier to reuse and debug.

## Validation

- `bash -n scripts/pr_review.sh scripts/pr_request.sh`
- `scripts/pr_report.py path 1`
- `scripts/pr_request.sh cmk/template-rust` (confirmed it now prints the underlying `gh` connection diagnostic)
- `scripts/pr_review.sh --check`
- `git diff --check`
- pre-commit hook: `cargo fmt --all -- --check`, `scripts/check_pii.sh`, `scripts/check_layers.sh`
- pre-push hook: `cargo test --workspace --quiet`, `cargo clippy --all-targets --quiet -- -D warnings`