### PR TITLE
Detect pushed workflow-state branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         run: cargo fmt --all -- --check
         continue-on-error: true
       - run: cargo test --workspace
+      - run: python3 -m unittest
       - run: cargo clippy --all-targets -- -D warnings
 
   deny:

--- a/scripts/workflow_state.sh
+++ b/scripts/workflow_state.sh
@@ -26,7 +26,9 @@ if [ -n "$pr_number" ]; then
   review_file=$(scripts/pr_report.py path "$pr_number")
 elif [ -n "${WORKFLOW_REVIEW_FILE:-}" ]; then
   review_file="$WORKFLOW_REVIEW_FILE"
-elif [ "${WORKFLOW_STATE_ALLOW_REVIEW_PATH_FALLBACK:-0}" = '1' ]; then
+fi
+
+if [ -z "$review_file" ] && [ "${WORKFLOW_STATE_ALLOW_REVIEW_PATH_FALLBACK:-0}" = '1' ]; then
   # Opt-in only: the no-arg fallback may consult GitHub to predict the
   # next PR number, which is too expensive for the default quick probe.
   review_file=$(scripts/pr_report.py path 2>/dev/null || true)
@@ -67,7 +69,8 @@ elif [ "$ahead" != 'unknown' ] && [ "$ahead" -gt 0 ]; then
   state='round_unpushed'
 elif [ -n "$pr_number" ]; then
   state='gh_review'
-elif [ "$ahead" = '0' ] && [ "$behind" = '0' ] && [ "$local_review" = 'present' ]; then
+elif [ "$ahead" = '0' ] && [ "$behind" = '0' ] \
+    && [ "$base_commits" != 'unknown' ] && [ "$base_commits" -gt 0 ]; then
   state='pushed'
 elif [ "$local_review" = 'present' ]; then
   state='local_reviewed'

--- a/tests/test_workflow_state.py
+++ b/tests/test_workflow_state.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_STATE_PATH = REPO_ROOT / "scripts" / "workflow_state.sh"
+
+
+def git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def run_state(repo: Path, script: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join(path for path in ("/bin", "/usr/bin") if Path(path).exists())
+    result = subprocess.run(
+        [str(script)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return dict(line.split(": ", 1) for line in result.stdout.strip().splitlines())
+
+
+class WorkflowStateTests(unittest.TestCase):
+    def test_clean_pushed_branch_without_gh_reports_pushed_without_review_file(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            remote = root / "origin.git"
+            repo = root / "repo"
+
+            subprocess.run(["git", "init", "--bare", remote], check=True, capture_output=True)
+            repo.mkdir()
+            git(repo, "init", "--initial-branch=main")
+            git(repo, "config", "user.name", "Workflow Test")
+            git(repo, "config", "user.email", "workflow@example.invalid")
+
+            scripts = repo / "scripts"
+            scripts.mkdir(parents=True)
+            script = scripts / "workflow_state.sh"
+            script.write_text(WORKFLOW_STATE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+            script.chmod(script.stat().st_mode | stat.S_IXUSR)
+            (repo / "README.md").write_text("seed\n", encoding="utf-8")
+
+            git(repo, "add", ".")
+            git(repo, "commit", "-m", "initial")
+            git(repo, "remote", "add", "origin", str(remote))
+            git(repo, "push", "-u", "origin", "main")
+
+            branch = "flat-fallback"
+            git(repo, "switch", "-c", branch)
+            (repo / "README.md").write_text("branch work\n", encoding="utf-8")
+            git(repo, "add", "README.md")
+            git(repo, "commit", "-m", "feat: branch work")
+            git(repo, "push", "-u", "origin", branch)
+
+            fields = run_state(repo, script)
+            self.assertEqual(fields["state"], "pushed")
+            self.assertEqual(fields["origin_branch_ahead"], "0")
+            self.assertEqual(fields["origin_branch_behind"], "0")
+            self.assertEqual(fields["review_file"], "unknown")
+            self.assertEqual(fields["local_review"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_state.py
+++ b/tests/test_workflow_state.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import os
 import stat
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,9 +18,12 @@ def git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
 
 
-def run_state(repo: Path, script: Path) -> dict[str, str]:
+def run_state(repo: Path, script: Path, path_prefix: Path) -> dict[str, str]:
     env = os.environ.copy()
-    env["PATH"] = os.pathsep.join(path for path in ("/bin", "/usr/bin") if Path(path).exists())
+    env.pop("WORKFLOW_REVIEW_FILE", None)
+    env.pop("WORKFLOW_STATE_ALLOW_REVIEW_PATH_FALLBACK", None)
+    base_path = env.get("PATH", "")
+    env["PATH"] = f"{path_prefix}{os.pathsep}{base_path}" if base_path else str(path_prefix)
     result = subprocess.run(
         [str(script)],
         cwd=repo,
@@ -44,7 +49,12 @@ class WorkflowStateTests(unittest.TestCase):
             git(repo, "config", "user.email", "workflow@example.invalid")
 
             scripts = repo / "scripts"
+            bin_dir = root / "bin"
             scripts.mkdir(parents=True)
+            bin_dir.mkdir()
+            gh = bin_dir / "gh"
+            gh.write_text(f"#!{sys.executable}\nimport sys\nsys.exit(1)\n", encoding="utf-8")
+            gh.chmod(gh.stat().st_mode | stat.S_IXUSR)
             script = scripts / "workflow_state.sh"
             script.write_text(WORKFLOW_STATE_PATH.read_text(encoding="utf-8"), encoding="utf-8")
             script.chmod(script.stat().st_mode | stat.S_IXUSR)
@@ -62,7 +72,14 @@ class WorkflowStateTests(unittest.TestCase):
             git(repo, "commit", "-m", "feat: branch work")
             git(repo, "push", "-u", "origin", branch)
 
-            fields = run_state(repo, script)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "WORKFLOW_REVIEW_FILE": "doc/reviews/review-99999.md",
+                    "WORKFLOW_STATE_ALLOW_REVIEW_PATH_FALLBACK": "1",
+                },
+            ):
+                fields = run_state(repo, script, bin_dir)
             self.assertEqual(fields["state"], "pushed")
             self.assertEqual(fields["origin_branch_ahead"], "0")
             self.assertEqual(fields["origin_branch_behind"], "0")


### PR DESCRIPTION
Fixes `scripts/workflow_state.sh` so clean, pushed branches no longer fall back to `impl_green` just because `gh pr view` cannot provide a PR number or a local review file is unavailable.

The script now reports `pushed` from git topology alone when a non-main branch is clean, has commits over `origin/main`, and is exactly even with `origin/<branch>`. If `gh pr view` can identify an open PR, that still upgrades the state to `gh_review`.

The regression test builds a temporary git repo with a bare `origin`, pushes a flat feature branch, hides `gh` from the state probe, and verifies the state is `pushed` even with no review file present.