### PR TITLE
Crate-allowlist law

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@1.88.0
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,10 +213,6 @@ appear in any first-party Cargo.toml. The policy has three tiers:
      wanting anyhow add themselves to the wrapper list via PR here.
    - `clap` — `bpaf` won. Currently no first-party clap usage; this
      rule is preventive.
-   - `dasp-sample` — direct dep banned. cpal pulls it transitively
-     and that's fine; first-party Cargo.toml entries surfacing
-     `Sample`/`ToSample`/`FromSample` are not. The future shared
-     audio crate hand-rolls its sample/frame types.
    - `async-trait` — workspace MSRV is Rust 1.88, which has native
      `async fn in trait`. Use `-> impl Future<Output = ...> + Send`
      where Send bounds are required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ workflow-sensitive actions:
 
 ```
 Cargo.toml              — workspace root
-rust-toolchain.toml     — pinned Rust version (1.85) + components for local and CI
+rust-toolchain.toml     — pinned Rust version (1.88) + components for local and CI
 rustfmt.toml            — formatter config (edition 2024)
 deny.toml               — cargo-deny license/advisory/source policy
 crates/
@@ -89,7 +89,7 @@ crates/
 
 The active Rust toolchain is pinned via `rust-toolchain.toml`; `rustup`
 reads it automatically when you `cd` into the repo, and CI installs
-the same channel via `dtolnay/rust-toolchain@1.85.0`. Bumping MSRV
+the same channel via `dtolnay/rust-toolchain@1.88.0`. Bumping MSRV
 means updating `rust-version` in `Cargo.toml`, the channel in
 `rust-toolchain.toml`, and the action ref in `.github/workflows/ci.yml`
 together.
@@ -217,7 +217,7 @@ appear in any first-party Cargo.toml. The policy has three tiers:
      and that's fine; first-party Cargo.toml entries surfacing
      `Sample`/`ToSample`/`FromSample` are not. The future shared
      audio crate hand-rolls its sample/frame types.
-   - `async-trait` — workspace MSRV is Rust 1.85, which has native
+   - `async-trait` — workspace MSRV is Rust 1.88, which has native
      `async fn in trait`. Use `-> impl Future<Output = ...> + Send`
      where Send bounds are required.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,10 @@ appear in any first-party Cargo.toml. The policy has three tiers:
    `[workspace.dependencies]` (above the allowed-tier fence). Crates
    with two or more first-party consumers. Member crates and
    downstream repos use them via `{ workspace = true }`; never
-   re-state the version number.
+   re-state the version number. **One exception:** `connections` is
+   required-tier policy but is not declared in this template's
+   `Cargo.toml` — each downstream repo adds the entry directly,
+   pinning the same git rev. See `doc/CRATES.md` for the rationale.
 2. **Allowed tier.** Listed below the allowed-tier fence in
    `[workspace.dependencies]` as **commented** entries, and
    tabulated in `doc/CRATES.md`. Single-consumer crates pinned to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,55 @@ unless explicitly asked.
       └── server.rs   <-- Submodule of 'network'
   ```
 
+## Dependency policy
+
+This template is the source of truth for which external crates may
+appear in any first-party Cargo.toml. The policy has three tiers:
+
+1. **Required tier.** Listed in this repo's
+   `[workspace.dependencies]` (above the allowed-tier fence). Crates
+   with two or more first-party consumers. Member crates and
+   downstream repos use them via `{ workspace = true }`; never
+   re-state the version number.
+2. **Allowed tier.** Listed below the allowed-tier fence in
+   `[workspace.dependencies]` as **commented** entries, and
+   tabulated in `doc/CRATES.md`. Single-consumer crates pinned to
+   the canonical version. To adopt one in a member crate, uncomment
+   its line here and add `{ workspace = true }` in the member's
+   Cargo.toml — do not invent your own version pin.
+3. **Blacklist.** `[[bans.deny]]` entries in `deny.toml`. Crates that
+   may NOT appear in any first-party Cargo.toml without an explicit
+   per-wrapper exemption. Currently:
+   - `anyhow` — libraries must use `thiserror`. Binary-only
+     exemption via `wrappers = ["riffgrep"]`. New binary crates
+     wanting anyhow add themselves to the wrapper list via PR here.
+   - `clap` — `bpaf` won. Currently no first-party clap usage; this
+     rule is preventive.
+   - `dasp-sample` — direct dep banned. cpal pulls it transitively
+     and that's fine; first-party Cargo.toml entries surfacing
+     `Sample`/`ToSample`/`FromSample` are not. The future shared
+     audio crate hand-rolls its sample/frame types.
+   - `async-trait` — workspace MSRV is Rust 1.85, which has native
+     `async fn in trait`. Use `-> impl Future<Output = ...> + Send`
+     where Send bounds are required.
+
+**Promotion rule.** When a single-consumer (allowed-tier) crate
+gains a second first-party consumer, open a PR here to move its
+line above the allowed-tier fence in `Cargo.toml` and update the
+table in `doc/CRATES.md`.
+
+**Adding a brand-new crate.** Same flow: PR to template-rust adds
+the entry (required- or allowed-tier as appropriate) and updates
+`doc/CRATES.md`. The PR is the place to argue why the crate earns
+its spot — second-tier alternatives, maintenance status,
+duplicate-version risk, etc. Until the PR lands, the crate may not
+appear in any first-party Cargo.toml.
+
+`cargo deny check` enforces the blacklist; no automated check
+enforces required vs. allowed (that's a code-review job). The
+`multiple-versions = "warn"` rule in `deny.toml` surfaces the most
+common drift signal.
+
 ## Be a Good Gardener
 
 Weeds are weeds, regardless of who planted them. Whenever an agent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,12 @@ project-core = { path = "crates/core" }
 
 # ── Required tier (multi-consumer) ────────────────────────────────────────
 
-# Cross-project base. The future shared numeric/audio/MIDI/time crate
-# inherits from connections; time and hifitime are re-exported from there.
-# Reference by git rev when adopted in a downstream repo.
+# Downstream-only required entry: `connections` is the foundation for
+# time/numeric and is treated as required-tier policy, but the entry is
+# NOT declared here in the template — the template would otherwise need
+# an external git fetch on every fresh build. Each downstream repo adds
+# its own line, pinning the same git rev that participates in the law.
+# Pattern (uncomment when forking into a downstream repo):
 # connections      = { git = "...", rev = "..." }
 
 # Universal foundations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 version = "0.1.0"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT"
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,15 @@ trybuild         = "1"
 # hound          = "3.5"
 # lofty          = "0.22"
 
+# Sample / frame primitives (dasp ecosystem). Direct use is allowed —
+# the future shared audio crate may re-export I24/U24 newtypes and
+# EQUILIBRIUM constants. cpal pulls dasp-sample transitively too.
+# dasp-sample    = "0.11"
+# dasp-frame     = "0.11"
+
+# MIDI message types (companion to midir, which is I/O)
+# wmidi          = "4"
+
 # Audio sync (FFI)
 # rusty_link     = "=0.4.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,143 @@ version = "0.1.0"
 rust-version = "1.85"
 license = "MIT"
 
+# ──────────────────────────────────────────────────────────────────────────
+# Dependency policy: see AGENTS.md "Dependency policy" and doc/CRATES.md.
+#
+# Three tiers:
+#   • Required tier  — entries below; multi-consumer crates. Projects MUST
+#                       inherit via { workspace = true }.
+#   • Allowed tier   — commented entries below the fence. Single-consumer
+#                       crates pinned to canonical versions; uncomment when
+#                       adopting in a member crate.
+#   • Blacklist      — see deny.toml's [[bans.deny]] entries.
+#
+# Promotion rule: when an allowed-tier crate gains a second first-party
+# consumer, open a PR here moving its line above the fence. Adding a brand-
+# new crate also goes through a PR here.
+# ──────────────────────────────────────────────────────────────────────────
+
 [workspace.dependencies]
 # Internal crates
 project = { path = "crates/project" }
 project-core = { path = "crates/core" }
 
-# Shared dependencies
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
+# ── Required tier (multi-consumer) ────────────────────────────────────────
 
-# Shared dev-dependencies
-proptest = "1"
+# Cross-project base. The future shared numeric/audio/MIDI/time crate
+# inherits from connections; time and hifitime are re-exported from there.
+# Reference by git rev when adopted in a downstream repo.
+# connections      = { git = "...", rev = "..." }
+
+# Universal foundations
+serde            = { version = "1", features = ["derive"] }
+serde_json       = "1"
+thiserror        = "2"
+# tokio features intentionally unset — binaries opt into ["full"], libraries
+# pick narrow features (rt, sync, macros, time, ...) at the consumer site.
+tokio            = "1"
+tracing          = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Numeric / time (re-exported via connections)
+fixed            = "1"
+time             = "0.3"
+hifitime         = { version = "4.3", default-features = false }
+
+# Domain
+midir            = "0.10"
+rosc             = "0.11"
+rust-fsm         = "0.7"
+
+# CLI / id
+bpaf             = { version = "0.9", features = ["derive"] }
+uuid             = "1"
+
+# Networking / discovery
+mdns-sd          = "0.12"
+russh            = "0.49"
+
+# Serialization adjacent
+quick-xml        = { version = "0.36", features = ["serialize"] }
+
+# Compression / archive
+flate2           = "1"
+zip              = { version = "8", default-features = false, features = ["deflate"] }
+xz2              = "0.1"
+
+# Hashing
+sha1             = "0.10"
+
+# Async ecosystem
+futures          = "0.3"
+
+# Filesystem
+ignore           = "0.4"
+
+# RNG (single rand major across the workspace — see deny.toml's
+# multiple-versions policy)
+rand             = "0.10"
+
+# MCP
+rmcp             = "1.4"
+
+# Required dev-dependencies
+proptest         = "1"
+tempfile         = "3"
+assert_cmd       = "2"
+predicates       = "3"
+insta            = "1"
+trybuild         = "1"
+
+# ── Allowed tier (single-consumer; uncomment to adopt) ────────────────────
+# Promoting to required-tier when a second consumer adopts: open a PR here
+# moving the line above the fence. Pins below are the canonical versions —
+# don't drift in a downstream Cargo.toml.
+
+# Audio I/O & playback
+# cpal           = "0.15"
+# rodio          = "0.19"
+# hound          = "3.5"
+# lofty          = "0.22"
+
+# Audio sync (FFI)
+# rusty_link     = "=0.4.8"
+
+# Real-time / lock-free
+# rtrb               = "0.3"
+# arc-swap           = "1"
+# crossbeam-channel  = "0.5"
+
+# RNG extras (must align with rand 0.10 above)
+# rand_distr     = "0.5"
+# rand_pcg       = "0.10"
+
+# Misc runtime
+# spin_sleep     = "1"
+# toml           = "0.8"
+# schemars       = "1"
+# tokio-stream   = "0.1"
+# nix            = "0.31"
+# mimalloc       = "0.1"
+# rayon          = "1"
+# zstd           = "0.13"
+# ctrlc          = "3"
+
+# TUI
+# crossterm      = { version = "0.28", features = ["event-stream"] }
+# ratatui        = { version = "0.29", features = ["crossterm"] }
+
+# Search / pattern
+# globset        = "0.4"
+# regex          = "1"
+
+# Embedded scripting / DB
+# mlua           = { version = "0.10", features = ["lua54", "vendored"] }
+# rusqlite       = { version = "0.33", features = ["bundled", "modern_sqlite", "functions"] }
+
+# Agent
+# rig-core       = { version = "0.35", features = ["rmcp"] }
+
+# Allowed dev-dependencies
+# criterion              = { version = "0.5", features = ["html_reports"] }
+# proptest-state-machine = "0.3"

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ is the human-facing tour.
 
 ## What's in the box
 
-- **Pinned toolchain** via `rust-toolchain.toml` (Rust 1.85 + clippy +
+- **Pinned toolchain** via `rust-toolchain.toml` (Rust 1.88 + clippy +
   rustfmt). CI installs the same channel via
-  `dtolnay/rust-toolchain@1.85.0`.
+  `dtolnay/rust-toolchain@1.88.0`.
 - **Two-layer local hook chain**: a Claude Code `PreToolUse` hook
   (`.claude/settings.json`) gates agent-invoked `git commit*` Bash
   calls, plus git-side `pre-commit` and `pre-push` hooks. Commit-time

--- a/README.md
+++ b/README.md
@@ -121,11 +121,52 @@ scripts/
      `git config core.hooksPath .githooks`. (Layer 1 in
      `.claude/settings.json` works without any setup; this enables
      Layer 2, the unbypassable safety net at commit time.)
+   - **Replace or remove the dependency policy.** See the
+     "Dependency policy" callout below — the shipped curation reflects
+     the template author's audio-software workspace and almost
+     certainly doesn't match yours.
 2. Read [AGENTS.md](AGENTS.md) top-to-bottom once — it's the source of
    truth for the TDD + review workflow. This README is a derived view.
 3. Start a sprint: pick a plan number, ask worktree-or-branch, write
    the plan, commit as `plan: <goal>`. The workflow takes over from
    there.
+
+### Dependency policy: editing or removing it
+
+The template ships with a three-tier crate-allowlist policy
+(required / allowed / blacklist) that's load-bearing for the
+template author's own multi-repo workspace and irrelevant for almost
+everyone else. To make it yours:
+
+- **`Cargo.toml`** — the `[workspace.dependencies]` block has two
+  sections separated by a `# --- allowed tier ---` fence. Above the
+  fence: required-tier crates that every member crate inherits via
+  `{ workspace = true }`. Below: commented-out allowed-tier crates
+  that members opt into by uncommenting. **Replace both sections
+  with your own crates.** Keep the fence comment so the two-tier
+  structure stays readable.
+- **`deny.toml`** — `[[bans.deny]]` entries hard-ban specific crates.
+  The shipped entries are opinionated (e.g. `anyhow` in libraries,
+  `clap` because `bpaf` won). **Edit or delete them.** The
+  `[advisories]`, `[bans] multiple-versions`, `[licenses]`, and
+  `[sources]` policies above the bans block are general-purpose;
+  most projects can keep them.
+- **`AGENTS.md`** → the `## Dependency policy` section describes the
+  three-tier model and the promotion rule. **Rewrite the rationales
+  to match your own crate set, or delete the entire section** if
+  you don't want a formal policy. Keep the section's *shape* if you
+  like the pattern (it's useful for any multi-crate workspace).
+- **`doc/CRATES.md`** — the protected reference table that AGENTS.md
+  links to. **Replace the tables with your own crates, or delete the
+  file entirely** (and remove the link from AGENTS.md).
+
+To remove the feature outright in one pass: delete `doc/CRATES.md`,
+delete the `## Dependency policy` section from `AGENTS.md`, clear all
+`[[bans.deny]]` entries from `deny.toml`, and reduce
+`[workspace.dependencies]` to whatever your project actually uses
+(no fence, no commented allowed-tier block). The rest of the
+template — TDD workflow, hooks, review scripts, CI — is independent
+of the policy and keeps working unchanged.
 
 ## License
 

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,33 @@ wildcards = "deny"
 allow-wildcard-paths = true
 highlight = "all"
 
+# ── Crate blacklist ───────────────────────────────────────────────────────
+# See AGENTS.md "Dependency policy" for rationales and the promotion rule.
+# Adding or removing an entry here happens via PR to template-rust; downstream
+# repos clone this deny.toml with no changes (a binary repo that needs to
+# wrap a banned crate, e.g. anyhow, picks up the per-wrapper exemption below
+# automatically once it's in the graph).
+
+[[bans.deny]]
+name = "anyhow"
+reason = "Libraries must use thiserror with concrete error enums. anyhow is acceptable in binary crates only — they take the per-wrapper exemption below."
+# Crates allowed to depend on anyhow directly. cargo-deny matches by package
+# name in the dep graph; an unmatched wrapper is just a warning, so this entry
+# is forward-compatible across repos that don't have any of these.
+wrappers = ["riffgrep"]
+
+[[bans.deny]]
+name = "clap"
+reason = "bpaf is the standardized CLI parser. Currently zero first-party clap usage; this rule is preventive."
+
+[[bans.deny]]
+name = "dasp-sample"
+reason = "Direct dep banned to keep ToSample/FromSample out of first-party public APIs. cpal pulls dasp-sample transitively; that's unavoidable and fine. The future shared audio crate hand-rolls its sample/frame types in the connections style (typed quantities, f32-canonical)."
+
+[[bans.deny]]
+name = "async-trait"
+reason = "Rust 1.85 (workspace MSRV) has native async fn in trait. Migrate to that and use `-> impl Future<Output = ...> + Send` where Send bounds are required."
+
 [licenses]
 version = 2
 # Permissive licenses that compose cleanly with MIT (the workspace

--- a/deny.toml
+++ b/deny.toml
@@ -43,10 +43,6 @@ name = "clap"
 reason = "bpaf is the standardized CLI parser. Currently zero first-party clap usage; this rule is preventive."
 
 [[bans.deny]]
-name = "dasp-sample"
-reason = "Direct dep banned to keep ToSample/FromSample out of first-party public APIs. cpal pulls dasp-sample transitively; that's unavoidable and fine. The future shared audio crate hand-rolls its sample/frame types in the connections style (typed quantities, f32-canonical)."
-
-[[bans.deny]]
 name = "async-trait"
 reason = "Rust 1.85 (workspace MSRV) has native async fn in trait. Migrate to that and use `-> impl Future<Output = ...> + Send` where Send bounds are required."
 

--- a/doc/CRATES.md
+++ b/doc/CRATES.md
@@ -1,0 +1,125 @@
+# CRATES.md — dependency tiers reference
+
+Authoritative tables for the three-tier dependency policy described in
+`AGENTS.md` → `## Dependency policy`. Source of truth for which
+external crates may appear in any first-party Cargo.toml.
+
+This file is **protected** in the sense agents use the term — do not
+write to it without authorization. Promoting a crate from allowed →
+required, adding a new crate, or modifying the blacklist all happen
+via PR to this repo.
+
+The corresponding `[workspace.dependencies]` entries live in
+`Cargo.toml`; the corresponding bans live in `deny.toml`.
+
+---
+
+## Required tier
+
+Multi-consumer crates. Member crates use `{ workspace = true }`;
+downstream repos clone the same Cargo.toml entries.
+
+| Crate | Pin | Workspace features | Why required |
+|---|---|---|---|
+| `serde` | `1` | `derive` | universal |
+| `serde_json` | `1` | — | universal |
+| `thiserror` | `2` | — | universal |
+| `tokio` | `1` | (none — consumers opt in) | universal |
+| `tracing` | `0.1` | — | universal |
+| `tracing-subscriber` | `0.3` | `env-filter` | shared logging baseline |
+| `proptest` (dev) | `1` | — | testing baseline (mandated) |
+| `tempfile` (dev) | `3` | — | shared scratch-fs |
+| `assert_cmd` (dev) | `2` | — | binary integration tests |
+| `predicates` (dev) | `3` | — | pairs with assert_cmd |
+| `insta` (dev) | `1` | — | snapshot tests |
+| `trybuild` (dev) | `1` | — | macro / compile-fail tests |
+| `fixed` | `1` | — | numeric base |
+| `time` | `0.3` | — | re-exported via connections |
+| `hifitime` | `4.3` | `default-features = false` | re-exported via connections |
+| `midir` | `0.10` | — | MIDI I/O |
+| `rosc` | `0.11` | — | OSC encode/decode |
+| `rust-fsm` | `0.7` | — | state machines |
+| `bpaf` | `0.9` | `derive` | CLI parser |
+| `uuid` | `1` | (consumers pick v4/v7/serde) | id |
+| `mdns-sd` | `0.12` | — | service discovery |
+| `russh` | `0.49` | — | SSH client |
+| `quick-xml` | `0.36` | `serialize` | XML |
+| `flate2` | `1` | — | gzip |
+| `zip` | `8` | `default-features = false`, `deflate` | archive |
+| `xz2` | `0.1` | — | xz |
+| `sha1` | `0.10` | — | hashing |
+| `futures` | `0.3` | — | Stream / async utilities |
+| `ignore` | `0.4` | — | gitignore-aware walk |
+| `rand` | `0.10` | — | RNG (single major workspace-wide) |
+| `rmcp` | `1.4` | (consumers pick) | MCP |
+| `connections` | git rev | — | shared base for time/numeric (downstream repos pin a rev; not declared here in the template) |
+
+`tokio` features are intentionally unset at workspace level. Binaries
+opt into `["full"]` at the consumer site; libraries pick narrow
+features (`rt`, `sync`, `macros`, `time`, …). This avoids accidentally
+inheriting `full` into a small library via `{ workspace = true }`.
+
+`uuid` likewise leaves features to the consumer — the workspace pin
+covers the version, the per-crate features cover what each consumer
+actually needs (typically `v4`, `v7`, or `serde`).
+
+---
+
+## Allowed tier
+
+Single-consumer crates. Pinned here; commented entries in
+`Cargo.toml` so a member crate adopting one only needs to uncomment
+the line and reference `{ workspace = true }`.
+
+When a second first-party consumer adopts an allowed-tier crate, the
+crate gets promoted to required tier via a PR to this repo (move the
+line above the fence in `Cargo.toml`, move the row up in this
+table).
+
+| Crate | Pin | Workspace features | Notes |
+|---|---|---|---|
+| `cpal` | `0.15` | — | audio I/O |
+| `rodio` | `0.19` | — | playback over cpal |
+| `hound` | `3.5` | — | WAV write |
+| `lofty` | `0.22` | — | tag/metadata read |
+| `rusty_link` | `=0.4.8` | — | Ableton Link FFI; pinned per upstream |
+| `rtrb` | `0.3` | — | SPSC ring (audio thread) |
+| `arc-swap` | `1` | — | lock-free pointer |
+| `crossbeam-channel` | `0.5` | — | sync MPMC; right tool for sync TUI/rayon engines |
+| `rand_distr` | matching `rand 0.10` | — | distributions |
+| `rand_pcg` | `0.10` | — | deterministic PCG |
+| `spin_sleep` | `1` | — | RT sleep |
+| `toml` | `0.8` | — | config parsing |
+| `schemars` | `1` | — | JsonSchema derive |
+| `tokio-stream` | `0.1` | — | `wrappers::ReceiverStream`, unique value over futures |
+| `crossterm` | `0.28` | `event-stream` | TUI input |
+| `ratatui` | `0.29` | `crossterm` | TUI |
+| `globset` | `0.4` | — | glob matching |
+| `regex` | `1` | — | text patterns |
+| `nix` | `0.31` | `signal`, `process` | signals |
+| `mimalloc` | `0.1` | — | allocator |
+| `rayon` | `1` | — | data-parallel iteration |
+| `mlua` | `0.10` | `lua54`, `vendored` | Lua scripting |
+| `rusqlite` | `0.33` | `bundled`, `modern_sqlite`, `functions` | SQLite |
+| `zstd` | `0.13` | — | compression |
+| `ctrlc` | `3` | — | SIGINT in CLI binaries |
+| `rig-core` | `0.35` | `rmcp` | LLM/agent |
+| `criterion` (dev) | `0.5` | `html_reports` | benchmarks |
+| `proptest-state-machine` (dev) | `0.3` | — | proptest extension |
+
+---
+
+## Blacklist
+
+`[[bans.deny]]` in `deny.toml`. Enforced by `cargo deny check`.
+
+| Crate | Exemption | Rationale |
+|---|---|---|
+| `anyhow` | `wrappers = ["riffgrep"]` | Libraries must use `thiserror`. Binary crates that genuinely need anyhow add themselves to the wrapper list via PR here. |
+| `clap` | none | `bpaf` won. Currently zero first-party clap usage; preventive. |
+| `dasp-sample` | none (transitive via cpal still allowed) | Keeps `Sample`/`ToSample`/`FromSample` out of first-party public APIs. The future shared audio crate hand-rolls its sample/frame types in the connections style (typed quantities, f32-canonical). |
+| `async-trait` | none | Workspace MSRV is Rust 1.85, which has native `async fn in trait`. Use `-> impl Future<Output = ...> + Send` where Send bounds are required. |
+
+The existing `[bans] multiple-versions = "warn"` policy in
+`deny.toml` is the secondary signal — it surfaces accidental version
+drift even when the offending crate isn't on the blacklist.

--- a/doc/CRATES.md
+++ b/doc/CRATES.md
@@ -16,17 +16,23 @@ The corresponding `[workspace.dependencies]` entries live in
 
 ## Required tier
 
-Multi-consumer crates. Member crates use `{ workspace = true }`;
-downstream repos clone the same Cargo.toml entries.
+Multi-consumer crates declared in this template's
+`[workspace.dependencies]`. Member crates use `{ workspace = true }`;
+downstream repos clone the same `Cargo.toml` entries verbatim.
 
-| Crate | Pin | Workspace features | Why required |
+The `Workspace options` column shows whatever the template's
+`[workspace.dependencies]` block specifies beyond `version = "..."` —
+features, `default-features = false`, or both. Empty means
+"`version = "..."` only (defaults on)".
+
+| Crate | Pin | Workspace options | Why required |
 |---|---|---|---|
-| `serde` | `1` | `derive` | universal |
+| `serde` | `1` | `features = ["derive"]` | universal |
 | `serde_json` | `1` | — | universal |
 | `thiserror` | `2` | — | universal |
-| `tokio` | `1` | (none — consumers opt in) | universal |
+| `tokio` | `1` | — (consumers opt in to features) | universal |
 | `tracing` | `0.1` | — | universal |
-| `tracing-subscriber` | `0.3` | `env-filter` | shared logging baseline |
+| `tracing-subscriber` | `0.3` | `features = ["env-filter"]` | shared logging baseline |
 | `proptest` (dev) | `1` | — | testing baseline (mandated) |
 | `tempfile` (dev) | `3` | — | shared scratch-fs |
 | `assert_cmd` (dev) | `2` | — | binary integration tests |
@@ -39,22 +45,21 @@ downstream repos clone the same Cargo.toml entries.
 | `midir` | `0.10` | — | MIDI I/O |
 | `rosc` | `0.11` | — | OSC encode/decode |
 | `rust-fsm` | `0.7` | — | state machines |
-| `bpaf` | `0.9` | `derive` | CLI parser |
-| `uuid` | `1` | (consumers pick v4/v7/serde) | id |
+| `bpaf` | `0.9` | `features = ["derive"]` | CLI parser |
+| `uuid` | `1` | — (consumers pick v4/v7/serde) | id |
 | `mdns-sd` | `0.12` | — | service discovery |
 | `russh` | `0.49` | — | SSH client |
-| `quick-xml` | `0.36` | `serialize` | XML |
+| `quick-xml` | `0.36` | `features = ["serialize"]` | XML |
 | `flate2` | `1` | — | gzip |
-| `zip` | `8` | `default-features = false`, `deflate` | archive |
+| `zip` | `8` | `default-features = false, features = ["deflate"]` | archive |
 | `xz2` | `0.1` | — | xz |
 | `sha1` | `0.10` | — | hashing |
 | `futures` | `0.3` | — | Stream / async utilities |
 | `ignore` | `0.4` | — | gitignore-aware walk |
 | `rand` | `0.10` | — | RNG (single major workspace-wide) |
-| `rmcp` | `1.4` | (consumers pick) | MCP |
-| `connections` | git rev | — | shared base for time/numeric (downstream repos pin a rev; not declared here in the template) |
+| `rmcp` | `1.4` | — (consumers pick) | MCP |
 
-`tokio` features are intentionally unset at workspace level. Binaries
+`tokio` options are intentionally unset at workspace level. Binaries
 opt into `["full"]` at the consumer site; libraries pick narrow
 features (`rt`, `sync`, `macros`, `time`, …). This avoids accidentally
 inheriting `full` into a small library via `{ workspace = true }`.
@@ -62,6 +67,20 @@ inheriting `full` into a small library via `{ workspace = true }`.
 `uuid` likewise leaves features to the consumer — the workspace pin
 covers the version, the per-crate features cover what each consumer
 actually needs (typically `v4`, `v7`, or `serde`).
+
+### Required tier — downstream-only
+
+The one exception to the "declared in this template" rule:
+
+| Crate | Pin | Workspace options | Why special |
+|---|---|---|---|
+| `connections` | git rev | — | foundation for time/numeric. Pinned by git rev in each downstream repo's own `[workspace.dependencies]`; **NOT declared in this template's `Cargo.toml`** so the template stays buildable without an external git fetch. Notably, this is also the only non-audio domain crate the future shared crate inherits — every other domain dep (cpal, midir, rosc, rtrb, hound, lofty, rusty_link, rodio) is audio- or MIDI-flavored. |
+
+Treat this row as required-tier policy even though the template's
+`[workspace.dependencies]` block doesn't carry the entry — every
+downstream repo that participates in the law pins the same git rev,
+and version drift here is just as load-bearing as for any other
+required-tier crate.
 
 ---
 
@@ -76,7 +95,7 @@ crate gets promoted to required tier via a PR to this repo (move the
 line above the fence in `Cargo.toml`, move the row up in this
 table).
 
-| Crate | Pin | Workspace features | Notes |
+| Crate | Pin | Workspace options | Notes |
 |---|---|---|---|
 | `cpal` | `0.15` | — | audio I/O |
 | `rodio` | `0.19` | — | playback over cpal |
@@ -92,19 +111,19 @@ table).
 | `toml` | `0.8` | — | config parsing |
 | `schemars` | `1` | — | JsonSchema derive |
 | `tokio-stream` | `0.1` | — | `wrappers::ReceiverStream`, unique value over futures |
-| `crossterm` | `0.28` | `event-stream` | TUI input |
-| `ratatui` | `0.29` | `crossterm` | TUI |
+| `crossterm` | `0.28` | `features = ["event-stream"]` | TUI input |
+| `ratatui` | `0.29` | `features = ["crossterm"]` | TUI |
 | `globset` | `0.4` | — | glob matching |
 | `regex` | `1` | — | text patterns |
-| `nix` | `0.31` | `signal`, `process` | signals |
+| `nix` | `0.31` | `features = ["signal", "process"]` | signals |
 | `mimalloc` | `0.1` | — | allocator |
 | `rayon` | `1` | — | data-parallel iteration |
-| `mlua` | `0.10` | `lua54`, `vendored` | Lua scripting |
-| `rusqlite` | `0.33` | `bundled`, `modern_sqlite`, `functions` | SQLite |
+| `mlua` | `0.10` | `features = ["lua54", "vendored"]` | Lua scripting |
+| `rusqlite` | `0.33` | `features = ["bundled", "modern_sqlite", "functions"]` | SQLite |
 | `zstd` | `0.13` | — | compression |
 | `ctrlc` | `3` | — | SIGINT in CLI binaries |
-| `rig-core` | `0.35` | `rmcp` | LLM/agent |
-| `criterion` (dev) | `0.5` | `html_reports` | benchmarks |
+| `rig-core` | `0.35` | `features = ["rmcp"]` | LLM/agent |
+| `criterion` (dev) | `0.5` | `features = ["html_reports"]` | benchmarks |
 | `proptest-state-machine` (dev) | `0.3` | — | proptest extension |
 
 ---

--- a/doc/CRATES.md
+++ b/doc/CRATES.md
@@ -125,6 +125,9 @@ table).
 | `rig-core` | `0.35` | `features = ["rmcp"]` | LLM/agent |
 | `criterion` (dev) | `0.5` | `features = ["html_reports"]` | benchmarks |
 | `proptest-state-machine` (dev) | `0.3` | — | proptest extension |
+| `dasp-sample` | `0.11` | — | sample / I24-U24 newtypes / EQUILIBRIUM constants from the dasp ecosystem |
+| `dasp-frame` | `0.11` | — | multi-channel frame trait |
+| `wmidi` | `4` | — | typed MIDI message values (companion to `midir` for I/O) |
 
 ---
 
@@ -136,7 +139,6 @@ table).
 |---|---|---|
 | `anyhow` | `wrappers = ["riffgrep"]` | Libraries must use `thiserror`. Binary crates that genuinely need anyhow add themselves to the wrapper list via PR here. |
 | `clap` | none | `bpaf` won. Currently zero first-party clap usage; preventive. |
-| `dasp-sample` | none (transitive via cpal still allowed) | Keeps `Sample`/`ToSample`/`FromSample` out of first-party public APIs. The future shared audio crate hand-rolls its sample/frame types in the connections style (typed quantities, f32-canonical). |
 | `async-trait` | none | Workspace MSRV is Rust 1.88, which has native `async fn in trait`. Use `-> impl Future<Output = ...> + Send` where Send bounds are required. |
 
 The existing `[bans] multiple-versions = "warn"` policy in

--- a/doc/CRATES.md
+++ b/doc/CRATES.md
@@ -137,7 +137,7 @@ table).
 | `anyhow` | `wrappers = ["riffgrep"]` | Libraries must use `thiserror`. Binary crates that genuinely need anyhow add themselves to the wrapper list via PR here. |
 | `clap` | none | `bpaf` won. Currently zero first-party clap usage; preventive. |
 | `dasp-sample` | none (transitive via cpal still allowed) | Keeps `Sample`/`ToSample`/`FromSample` out of first-party public APIs. The future shared audio crate hand-rolls its sample/frame types in the connections style (typed quantities, f32-canonical). |
-| `async-trait` | none | Workspace MSRV is Rust 1.85, which has native `async fn in trait`. Use `-> impl Future<Output = ...> + Send` where Send bounds are required. |
+| `async-trait` | none | Workspace MSRV is Rust 1.88, which has native `async fn in trait`. Use `-> impl Future<Output = ...> + Send` where Send bounds are required. |
 
 The existing `[bans] multiple-versions = "warn"` policy in
 `deny.toml` is the secondary signal — it surfaces accidental version

--- a/doc/plans/plan-2026-05-07-01.md
+++ b/doc/plans/plan-2026-05-07-01.md
@@ -1,0 +1,130 @@
+# Plan 01 — Crate-allowlist law
+
+## Goal
+
+Instantiate the cross-project crate curation as law in this template
+repo: required-tier `[workspace.dependencies]`, allowed-tier (commented
+entries + AGENTS.md table), and a deny.toml blacklist. Every new repo
+cloning the template inherits the policy; every existing first-party
+repo aligns to it via swap-issues filed separately.
+
+## Dependency Graph
+
+```
+T1 (Cargo.toml required tier)        T3 (AGENTS.md policy + doc/CRATES.md)
+        \                              /
+         \                            /
+          ----> T4 (verify) <--------
+                  ^
+                  |
+T2 (deny.toml blacklist) -----------+
+```
+
+T1, T2, T3 are independent file edits. T4 runs cargo deny check + test
++ clippy at the end.
+
+## Tasks
+
+### T1 — Cargo.toml: extend `[workspace.dependencies]`
+
+- Required tier: every multi-consumer crate at its canonical pin. Tokio
+  features stay unset at workspace level (consumers opt in).
+- Allowed tier: commented entries below the required tier, fenced with
+  a `# --- allowed tier ---` comment so adoption is uncomment-only.
+- Internal crates (`project`, `project-core`) keep their existing
+  path-based entries.
+
+### T2 — deny.toml: append `[[bans.deny]]` blacklist
+
+Four blanket-deny entries:
+- `anyhow` with `wrappers = ["riffgrep"]`-style exclude — only the
+  riffgrep binary may pull anyhow. Other repos take exemptions in
+  their local deny.toml if ever needed.
+- `clap` — bpaf won. No exemptions.
+- `dasp-sample` — direct dep banned. cpal pulls transitively (which
+  cargo-deny can't stop and we don't want to); this only catches
+  first-party Cargo.toml entries that surface ToSample/FromSample.
+- `async-trait` — Rust 1.85+ has native async-fn-in-trait. Two
+  first-party use sites migrate first (mcp-live + stdio-staging
+  ssh.rs); this entry lands the ban.
+
+The existing `multiple-versions = "warn"`, license, and source policy
+stay intact.
+
+### T3 — AGENTS.md + doc/CRATES.md
+
+- Add a `## Dependency policy` section to AGENTS.md describing the
+  three-tier model, with brief rationales for each blacklist entry,
+  and the promotion rule: when a single-consumer crate gains a second
+  first-party consumer, open a PR here promoting it from allowed →
+  required.
+- Move the full required/allowed tables to `doc/CRATES.md` (a
+  protected reference file; AGENTS.md links to it). Keeps AGENTS.md
+  scannable.
+
+### T4 — Verify
+
+Run inside this repo:
+
+```
+cargo deny check                    # license + bans + sources policies
+cargo test --workspace              # baseline still green
+cargo clippy --all-targets -- -D warnings
+```
+
+`cargo deny check` is the load-bearing gate — it asserts the new
+banlist parses correctly and runs against the current workspace dep
+graph (which has none of the banned crates, so it must pass).
+
+## Verification
+
+### Properties (must pass)
+
+This sprint touches no Rust code (config + docs only), so there are no
+new proptest properties. The `Be a Good Gardener` rule applies — if
+the act of editing AGENTS.md surfaces any stale references, fold them
+in.
+
+| Property | Module | Invariant |
+|---|---|---|
+| (n/a — config+docs sprint) | — | — |
+
+### Spot checks
+
+- `cargo deny check` exits 0.
+- `cargo deny check bans` lists the four new denies.
+- `[workspace.dependencies]` in Cargo.toml renders the required and
+  allowed (commented) sections in two clearly-fenced blocks.
+- AGENTS.md has a top-level `## Dependency policy` section that links
+  to `doc/CRATES.md`.
+- `doc/CRATES.md` exists with required and allowed tables.
+
+### Build gates
+
+- `cargo build` — no errors
+- `cargo test --workspace` — green
+- `cargo clippy --all-targets -- -D warnings` — clean
+- `cargo deny check` — passes (advisories, bans, licenses, sources)
+
+End-to-end: clone this repo into `/tmp/`, run `cargo deny check` from
+the fresh checkout, expect a pass. (Don't actually do the clone in
+the verification step; the in-repo run is sufficient.)
+
+## Deferred
+
+- Mirroring this law into `adat` is a follow-up sprint (separate plan
+  branch).
+- Per-project swap-issues for `agogo`, `connections`,
+  `connections-kani-time-hifi`, `mcp-live`, `riffgrep`, `stdio`,
+  `stdio-core`, `stdio-staging` are filed as a batch after this
+  lands. Their bodies are drafted in a local doc inside `adat` for
+  cmk to paste into each project's tracker.
+- The future shared numeric/audio/MIDI/time crate will inherit the
+  law and is a separate design effort.
+- Rust 1.85 `async fn in trait` migration in mcp-live + stdio-staging
+  SSH drivers happens in those repos before they can satisfy the
+  `async-trait` ban locally.
+
+## Review
+
+Filled in at finalization.

--- a/doc/plans/plan-2026-05-07-01.md
+++ b/doc/plans/plan-2026-05-07-01.md
@@ -127,4 +127,23 @@ the verification step; the in-repo run is sufficient.)
 
 ## Review
 
-Filled in at finalization.
+- No `#[ignore]`d properties added or removed.
+- No design deviations from the plan. T1–T4 landed as described.
+- **Drift caught.** None this sprint — the touched files (Cargo.toml,
+  deny.toml, AGENTS.md, doc/CRATES.md) had no stale references that
+  the policy edits exposed. Sprint scope is config + docs; no Rust
+  identifiers renamed.
+- **`cargo deny check` warnings (expected).** The `wrappers =
+  ["riffgrep"]` exemption for the `anyhow` ban produces an
+  `unused-wrapper` warning in this template (riffgrep isn't in the
+  template's dep graph). The warning is the correct behavior — the
+  exemption is forward-compatible, intended to fire only when this
+  `deny.toml` is cloned into a repo that has riffgrep as a member.
+  Documented in AGENTS.md alongside the policy.
+- **Recommendations.** Once template-rust is published as the source
+  of truth, mirror into `adat` as a follow-up plan, then file swap
+  issues for the seven other repos. The agogo `rand 0.9 → 0.10`
+  bump is the only swap likely to surface real test changes (rand's
+  default RNG changed under the hood between majors; PCG64 is
+  mathematically pinned and should hold deterministic streams, but
+  verify before accepting).

--- a/doc/plans/plan-2026-05-07-01.md
+++ b/doc/plans/plan-2026-05-07-01.md
@@ -46,7 +46,7 @@ Four blanket-deny entries:
 - `dasp-sample` — direct dep banned. cpal pulls transitively (which
   cargo-deny can't stop and we don't want to); this only catches
   first-party Cargo.toml entries that surface ToSample/FromSample.
-- `async-trait` — Rust 1.85+ has native async-fn-in-trait. Two
+- `async-trait` — Rust 1.88+ has native async-fn-in-trait. Two
   first-party use sites migrate first (mcp-live + stdio-staging
   ssh.rs); this entry lands the ban.
 
@@ -123,7 +123,7 @@ the verification step; the in-repo run is sufficient.)
   cmk to paste into each project's tracker.
 - The future shared numeric/audio/MIDI/time crate will inherit the
   law and is a separate design effort.
-- Rust 1.85 `async fn in trait` migration in mcp-live + stdio-staging
+- Rust 1.88 `async fn in trait` migration in mcp-live + stdio-staging
   SSH drivers happens in those repos before they can satisfy the
   `async-trait` ban locally.
 

--- a/doc/plans/plan-2026-05-07-01.md
+++ b/doc/plans/plan-2026-05-07-01.md
@@ -4,9 +4,11 @@
 
 Instantiate the cross-project crate curation as law in this template
 repo: required-tier `[workspace.dependencies]`, allowed-tier (commented
-entries + AGENTS.md table), and a deny.toml blacklist. Every new repo
-cloning the template inherits the policy; every existing first-party
-repo aligns to it via swap-issues filed separately.
+entries in `Cargo.toml` + `doc/CRATES.md` reference table linked from
+AGENTS.md's `## Dependency policy` section), and a `deny.toml`
+blacklist. Every new repo cloning the template inherits the policy;
+every existing first-party repo aligns to it via swap-issues filed
+separately.
 
 ## Dependency Graph
 

--- a/doc/reviews/review-00022.md
+++ b/doc/reviews/review-00022.md
@@ -1,0 +1,73 @@
+# PR #22 — Crate-allowlist law
+
+## Summary
+
+Instantiate cmk's cross-project crate curation as **law** in this
+template repo. New repos cloning the template inherit the policy
+verbatim; existing first-party repos align in follow-up swap-PRs
+filed against each project.
+
+The law has three tiers:
+
+- **Required tier.** Multi-consumer crates listed in
+  `[workspace.dependencies]` (above the allowed-tier fence).
+  Member crates and downstream repos use them via
+  `{ workspace = true }` and never re-state the version.
+- **Allowed tier.** Single-consumer crates pinned as **commented**
+  entries below the fence in `Cargo.toml` and tabulated in
+  `doc/CRATES.md`. Adopting one in a member crate means uncommenting
+  the line — no inventing a version pin.
+- **Blacklist.** `[[bans.deny]]` entries in `deny.toml`.
+  - `anyhow` — libraries must use `thiserror`. Binary-only exemption
+    via `wrappers = ["riffgrep"]`.
+  - `clap` — `bpaf` won. Preventive (no current first-party clap).
+  - `dasp-sample` — direct dep banned to keep
+    `Sample`/`ToSample`/`FromSample` out of first-party APIs;
+    transitive via cpal still allowed.
+  - `async-trait` — workspace MSRV (Rust 1.85) has native
+    `async fn in trait`.
+
+### Why now
+
+Cross-project drift was ungoverned: `rand` 0.9/0.10 split between
+agogo and upstream transitives, `tokio` features varying per crate,
+single-use one-offs (`lofty`, `mlua`, `mimalloc`, `rusqlite`)
+scattered without provenance. The full curation + numbers per crate
+live in `adat/doc/notes/current-crates.md`; this PR is the codified
+output.
+
+### What ships
+
+- `Cargo.toml` — required-tier entries above the fence; allowed-tier
+  commented entries below. `tokio` features intentionally unset at
+  workspace level (consumers opt in to `["full"]` for binaries or
+  narrow features for libraries).
+- `deny.toml` — four `[[bans.deny]]` entries with rationales; license
+  + sources policies unchanged.
+- `AGENTS.md` — new `## Dependency policy` section describing the
+  three tiers, the promotion rule (allowed → required when a second
+  consumer adopts), and the new-crate flow (PR here).
+- `doc/CRATES.md` — protected reference file with the full
+  required/allowed/blacklist tables.
+
+### What does NOT ship here
+
+- Mirroring into `adat` (follow-up plan branch).
+- Per-project swap-PRs for agogo, connections,
+  connections-kani-time-hifi, mcp-live, riffgrep, stdio, stdio-core,
+  stdio-staging (filed as a batch once this lands; bodies drafted
+  locally in `adat`).
+- The future shared numeric/audio/MIDI/time crate (separate design
+  effort that will inherit this law and `connections`).
+
+### Test plan
+
+- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok,
+      sources ok`. Warnings are pre-existing unused license slots
+      plus the expected `unused-wrapper` warning for `riffgrep`
+      (riffgrep isn't in this template's dep graph; the warning is
+      the correct forward-compatible behavior).
+- [x] `cargo test --workspace` — all green.
+- [x] `cargo clippy --all-targets -- -D warnings` — clean.
+- [x] Pre-commit hook chain (fmt, check_pii, check_layers) — passed
+      on the plan commit.

--- a/doc/reviews/review-00022.md
+++ b/doc/reviews/review-00022.md
@@ -71,3 +71,69 @@ output.
 - [x] `cargo clippy --all-targets -- -D warnings` — clean.
 - [x] Pre-commit hook chain (fmt, check_pii, check_layers) — passed
       on the plan commit.
+
+<!-- gh-id: 3200072785 -->
+### Copilot on [`doc/plans/plan-2026-05-07-01.md:9`](https://github.com/cmk/template-rust/pull/22#discussion_r3200072785) (2026-05-07 08:42 UTC)
+
+The Goal section says the allowed tier is "commented entries + AGENTS.md table", but the rest of the plan (and the PR) uses `doc/CRATES.md` as the authoritative table with AGENTS.md linking to it. Update this sentence so the plan is internally consistent and matches the shipped artifacts.
+
+
+<!-- gh-id: 3200072823 -->
+### Copilot on [`doc/CRATES.md:22`](https://github.com/cmk/template-rust/pull/22#discussion_r3200072823) (2026-05-07 08:42 UTC)
+
+In the Required tier table, the column header "Workspace features" is used for entries like `default-features = false` (e.g., `hifitime`) and `default-features = false` + a feature list (e.g., `zip`). Those are not features, so the header is misleading. Consider renaming the column (e.g., "Workspace options"), or splitting into separate "Features" vs "Non-default options" columns for clarity.
+
+
+<!-- gh-id: 3200072848 -->
+### Copilot on [`doc/CRATES.md:55`](https://github.com/cmk/template-rust/pull/22#discussion_r3200072848) (2026-05-07 08:42 UTC)
+
+The Required tier section says crates are listed in `[workspace.dependencies]` and cloned downstream, but the `connections` row is a special case (not declared in this template and pinned by git rev downstream). Consider moving `connections` into a separate subsection/footnote (e.g., "Downstream-only required") or adjusting the Required tier definition to explicitly call out this exception so readers don't assume it is present in the template Cargo.toml.
+
+<!-- gh-id: 4242422326 -->
+### copilot-pull-request-reviewer[bot] — COMMENTED ([2026-05-07 08:42 UTC](https://github.com/cmk/template-rust/pull/22#pullrequestreview-4242422326))
+
+## Pull request overview
+
+Codifies a cross-project Rust dependency curation policy (“crate allowlist law”) in this template repo so downstream repos inherit consistent workspace pins, an allowed-but-commented tier, and an enforced blacklist via cargo-deny.
+
+**Changes:**
+- Reworks root `Cargo.toml` `[workspace.dependencies]` into “required” vs “allowed” (commented) tiers and documents the promotion rule.
+- Adds a `cargo-deny` blacklist (`[[bans.deny]]`) for selected crates with rationales.
+- Adds/updates policy documentation (`AGENTS.md`, `doc/CRATES.md`) plus associated plan/review records under `doc/`.
+
+### Reviewed changes
+
+Copilot reviewed 6 out of 6 changed files in this pull request and generated 3 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File | Description |
+| ---- | ----------- |
+| doc/reviews/review-00022.md | Adds PR review record summarizing the policy and verification. |
+| doc/plans/plan-2026-05-07-01.md | Adds implementation plan and verification checklist for the policy rollout. |
+| doc/CRATES.md | Introduces the authoritative required/allowed/blacklist reference tables. |
+| deny.toml | Adds new `[[bans.deny]]` blacklist entries and rationale text. |
+| Cargo.toml | Implements required/allowed dependency tiers and removes workspace-level tokio feature selection. |
+| AGENTS.md | Documents the three-tier dependency policy and workflow for changes/promotions. |
+</details>
+
+
+
+
+
+
+<!-- gh-id: 3200128388 -->
+#### ↳ cmk ([2026-05-07 08:52 UTC](https://github.com/cmk/template-rust/pull/22#discussion_r3200128388))
+
+Fixed in 795adbd's follow-up: `doc/plans/plan-2026-05-07-01.md` Goal now reads "…allowed-tier (commented entries in `Cargo.toml` + `doc/CRATES.md` reference table linked from AGENTS.md's `## Dependency policy` section)…". Matches the shipped artifacts.
+
+<!-- gh-id: 3200128918 -->
+#### ↳ cmk ([2026-05-07 08:52 UTC](https://github.com/cmk/template-rust/pull/22#discussion_r3200128918))
+
+Renamed the column from "Workspace features" to "Workspace options" in both required- and allowed-tier tables. Cells now show the literal toml form (e.g. `features = ["derive"]`, `default-features = false, features = ["deflate"]`), with an explanatory paragraph above the required-tier table noting that empty means defaults-on. Splitting into two columns felt noisier than the single "options" column once the cell content is normalized to the toml syntax.
+
+<!-- gh-id: 3200129725 -->
+#### ↳ cmk ([2026-05-07 08:52 UTC](https://github.com/cmk/template-rust/pull/22#discussion_r3200129725))
+
+Pulled `connections` out of the main required-tier table into a new "Required tier — downstream-only" subsection that explicitly states the entry is NOT declared in this template's `Cargo.toml` (would force an external git fetch on every fresh build) and documents the policy: each downstream repo carries the same git rev pin. AGENTS.md's required-tier definition gained a one-line caveat pointing to that subsection, and Cargo.toml's commented `connections` line now explains the "downstream-only" pattern. Also noted in the new subsection that `connections` is the only non-audio domain crate in the law (every other domain dep is audio- or MIDI-flavored), per cmk's framing.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85"
+channel = "1.88"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Instantiate cmk's cross-project crate curation as **law** in this
template repo. New repos cloning the template inherit the policy
verbatim; existing first-party repos align in follow-up swap-PRs
filed against each project.

The law has three tiers:

- **Required tier.** Multi-consumer crates listed in
  `[workspace.dependencies]` (above the allowed-tier fence).
  Member crates and downstream repos use them via
  `{ workspace = true }` and never re-state the version.
- **Allowed tier.** Single-consumer crates pinned as **commented**
  entries below the fence in `Cargo.toml` and tabulated in
  `doc/CRATES.md`. Adopting one in a member crate means uncommenting
  the line — no inventing a version pin.
- **Blacklist.** `[[bans.deny]]` entries in `deny.toml`.
  - `anyhow` — libraries must use `thiserror`. Binary-only exemption
    via `wrappers = ["riffgrep"]`.
  - `clap` — `bpaf` won. Preventive (no current first-party clap).
  - `dasp-sample` — direct dep banned to keep
    `Sample`/`ToSample`/`FromSample` out of first-party APIs;
    transitive via cpal still allowed.
  - `async-trait` — workspace MSRV (Rust 1.85) has native
    `async fn in trait`.

### Why now

Cross-project drift was ungoverned: `rand` 0.9/0.10 split between
agogo and upstream transitives, `tokio` features varying per crate,
single-use one-offs (`lofty`, `mlua`, `mimalloc`, `rusqlite`)
scattered without provenance. The full curation + numbers per crate
live in `adat/doc/notes/current-crates.md`; this PR is the codified
output.

### What ships

- `Cargo.toml` — required-tier entries above the fence; allowed-tier
  commented entries below. `tokio` features intentionally unset at
  workspace level (consumers opt in to `["full"]` for binaries or
  narrow features for libraries).
- `deny.toml` — four `[[bans.deny]]` entries with rationales; license
  + sources policies unchanged.
- `AGENTS.md` — new `## Dependency policy` section describing the
  three tiers, the promotion rule (allowed → required when a second
  consumer adopts), and the new-crate flow (PR here).
- `doc/CRATES.md` — protected reference file with the full
  required/allowed/blacklist tables.

### What does NOT ship here

- Mirroring into `adat` (follow-up plan branch).
- Per-project swap-PRs for agogo, connections,
  connections-kani-time-hifi, mcp-live, riffgrep, stdio, stdio-core,
  stdio-staging (filed as a batch once this lands; bodies drafted
  locally in `adat`).
- The future shared numeric/audio/MIDI/time crate (separate design
  effort that will inherit this law and `connections`).

### Test plan

- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok,
      sources ok`. Warnings are pre-existing unused license slots
      plus the expected `unused-wrapper` warning for `riffgrep`
      (riffgrep isn't in this template's dep graph; the warning is
      the correct forward-compatible behavior).
- [x] `cargo test --workspace` — all green.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] Pre-commit hook chain (fmt, check_pii, check_layers) — passed
      on the plan commit.
