### PR TITLE
Port connections review-prompt sharpening upstream

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,5 +1,5 @@
 ---
-description: Tier-1 local pre-push code review. Spawns an independent reviewer agent to examine the branch diff against origin/main and writes the review to doc/reviews/review-NNNNN.md.
+description: Tier-1 local pre-push code review. Invokes scripts/pr_review.sh, which runs codex review against origin/main and appends findings to doc/reviews/review-NNNNN.md. The agent does not author the reviewer prompt.
 argument-hint: (no args)
 ---
 
@@ -9,15 +9,22 @@ You are orchestrating the Claude Code implementation of the
 `plan_finalized → local_reviewed` FSM transition: a **local, pre-push**
 code review. This is Tier 1 of a two-tier system:
 
-- **Tier 1 (this command):** Independent agent reviews `origin/main...HEAD` locally.
-  Gate before pushing.
-- **Tier 2 (GitHub):** After push, CI runs `cargo test --workspace` and
-  `cargo clippy --all-targets -- -D warnings` (see
-  `.github/workflows/ci.yml`). Claude Code Action and/or Copilot review
-  the PR on GitHub.
+- **Tier 1 (this command):** `scripts/pr_review.sh` runs `codex review
+  --base origin/main` against the branch. Codex auto-loads `AGENTS.md`
+  + `doc/reviews/calibration.md` from disk as its system prompt.
+  Output is appended to `doc/reviews/review-NNNNN.md`.
+- **Tier 2 (GitHub):** After push, CI runs `cargo test --workspace`
+  and `cargo clippy --all-targets -- -D warnings` (see
+  `.github/workflows/ci.yml`). Claude Code Action and/or Copilot
+  review the PR on GitHub.
 
-Your job: gather inputs, launch the reviewer, place the output, then help
-the user push if the review passes.
+**Your role is the orchestrator, not the reviewer.** You run
+prerequisite checks, invoke the script, read back what codex wrote,
+and triage auto-fixable items. You do **not** author a reviewer
+prompt. You do **not** spawn a Claude subagent. You do **not** gather
+context to feed an agent — codex picks up the contract files itself.
+Anything you do beyond running the script is the failure mode this
+command exists to prevent: the agent shaping its own review.
 
 ---
 
@@ -36,37 +43,22 @@ If any fixups exist, run `scripts/git_squash.sh` to collapse them.
 Abort if the working tree is dirty (the script checks this). After
 autosquash, re-run the fixup check to confirm the branch is clean.
 
-## Step 1: Identify the plan (optional)
-
-Check for a plan doc associated with this branch:
-
-```
-ls -t doc/plans/plan-*.md | head -3
-```
-
-If a plan exists and is clearly related to the branch work (check dates,
-topic), read it. You'll pass its text to the reviewer.
-
-If no plan exists or none is relevant, that's fine — the review proceeds
-in **code-only mode** (no plan-conformance section).
-
-## Step 2: Collect the diff and verify prerequisites
+## Step 1: Verify prerequisites
 
 The review always targets the current branch against `origin/main`.
-Refresh the ref first so the base isn't stale:
+Refresh the ref and confirm the branch has diverged:
 
 ```
 git fetch --quiet origin main
-git diff origin/main...HEAD
-git log origin/main..HEAD --oneline
+git diff origin/main...HEAD >/dev/null && echo "no diff to review" || true
 ```
 
-If the branch has not diverged from `origin/main`, abort with a
-message — there's nothing to review.
+If `git diff --quiet origin/main...HEAD` exits 0, abort — there's
+nothing to review.
 
-**Verify the review file exists.** `/pr-review` appends to a
-file created by TDD step 7; it never creates the file itself. Get
-its path:
+**Verify the review file exists.** `pr_review.sh` appends to a file
+created by TDD step 7; it never creates the file itself. Get its
+path:
 
 - If a PR already exists for this branch:
   ```
@@ -78,193 +70,42 @@ its path:
   ```
 
 `pr_report.py path` predicts (or accepts) the PR number and emits the
-zero-padded filename — no need to compose the path by hand. Then
-confirm the returned path exists **and contains a `## Summary`
-section**. If either is missing, abort and tell the user to run TDD
-step 7 (finalize plan + draft PR description). Do not create the
-file and do not proceed to the reviewer — the PR body belongs in
-that commit, not as a post-hoc fabrication by this command.
+zero-padded filename. Confirm the returned path exists **and contains
+a `## Summary` section**. If either is missing, abort and tell the
+user to run TDD step 7. Do not create the file yourself — the PR body
+belongs in step 7's commit, not as a post-hoc fabrication.
 
-## Step 3: Gather context
+## Step 2: Run codex via scripts/pr_review.sh
 
-Read these files and include them in the reviewer prompt:
+Invoke `scripts/pr_review.sh`. It runs `codex review --base
+origin/main`, reads `AGENTS.md` automatically as the reviewer system
+prompt (that's the contract — the reviewer's instructions live in
+`AGENTS.md` and `doc/reviews/calibration.md` on disk, not in this
+file), and appends a `## Local review (YYYY-MM-DD)` section to the
+review file.
 
-- `AGENTS.md` — repo conventions, workspace layout, TDD workflow, commit
-  style, feature-gate conventions
-- `doc/reviews/calibration.md` — if it exists, include as few-shot
-  examples. If absent, skip (the reviewer prompt has built-in guidance).
+**Do not author a prompt. Do not pass context to a subagent. Do not
+launch an agent yourself.** The orchestrator (you) has zero authoring
+role in how the diff is handed off — the reviewer is codex; codex's
+prompt is `AGENTS.md` + `doc/reviews/calibration.md` on disk; the
+script wires them together. Anything you do beyond running the
+script is the failure mode this command exists to prevent.
 
-## Step 4: Launch the reviewer
+If `pr_review.sh` exits non-zero, surface stderr and stop. Do not
+retry with hand-rolled inputs. Do not invent a reviewer prompt
+yourself.
 
-Spawn a **new agent** with `subagent_type: "feature-dev:code-reviewer"` and
-`model: "sonnet"`.
+## Step 3: Read back the appended review section
 
-The prompt must be self-contained. Include:
+Capture the section codex appended to the review file so Step 4 can
+triage it. No interpretation, no summarization — pass it through
+verbatim to the triage logic. (`tail` from a recorded byte-offset, or
+re-read the file and slice from the last `## Local review` heading
+onward.)
 
-1. The full diff
-2. The commit log
-3. The repo conventions from AGENTS.md
-4. The plan text (if found), clearly labeled as optional context
-5. Calibration examples from `doc/reviews/calibration.md` (if found)
-6. The review instructions (below)
+## Step 4: Triage and apply auto-fixable items
 
-### Reviewer voice and calibration
-
-The reviewer should write like a thorough human PR reviewer, not a checklist
-robot. Good review comments share these qualities:
-
-- **Cite the contract, then the violation.** When the plan says X and the code
-  does Y, quote both. "The plan specifies `device = ["dep:tokio", ...]` as an
-  optional feature gate (T1), but `Cargo.toml` lists tokio as unconditional."
-
-- **Name the consequence.** Don't just say "this differs from the plan." Say
-  what breaks: "This means `driver-motu` links tokio/russh/mdns despite only
-  using HTTP+OSC, adding ~3s to clean builds."
-
-- **Distinguish severity.** Some findings block the merge, others are
-  improvement opportunities. Be explicit: "Must fix before merge" vs
-  "Consider for a follow-up."
-
-- **Don't pad.** If a section has no findings, one sentence: "All N planned
-  tests are present and correctly gated." Don't invent concerns to fill space.
-
-### Reviewer prompt template
-
-~~~
-You are reviewing code on a local feature branch before it is pushed to
-GitHub. This is a pre-push quality gate — there is no PR yet. You are
-reviewing the diff between `origin/main` and the branch HEAD.
-
-You are an independent reviewer. You did not write this code and have no
-context beyond what is provided here. Review what you see, not what you
-assume.
-
-## Diff (origin/main...HEAD)
-
-{diff}
-
-## Commit log (origin/main..HEAD)
-
-{commit log}
-
-## Repo conventions
-
-{AGENTS.md contents}
-
-{IF plan exists:}
-## Sprint plan (optional context)
-
-{plan text}
-
-The plan is context, not a contract. Focus on whether the code is correct,
-tested, and follows conventions. If the plan specifies verification criteria
-(property tests, spot checks), confirm they exist in the diff.
-{END IF}
-
-{IF calibration examples exist:}
-## Examples of high-quality review comments
-
-{doc/reviews/calibration.md contents}
-
-Match this style: cite the contract (doc, plan, or naming), show how the
-code violates it, and name the consequence. When something is fine, one
-sentence is enough. Don't invent concerns to fill space.
-{END IF}
-
-## Review instructions
-
-For each section, state what you found concretely. When something is wrong,
-cite the specific file, line, and consequence. When something is fine, one
-sentence is enough — don't pad.
-
-### Commit Hygiene
-
-- Does each commit leave the repo in a buildable, testable state?
-- Are commit messages conventional (feat/fix/doc/test/task/debt prefix, optional scope)?
-- Are commits reasonably atomic, or are unrelated changes mixed?
-
-### Code Quality
-
-- Does the code follow repo conventions (thiserror in libs, no unsafe,
-  lints via Cargo.toml)?
-- Are error messages specific enough to diagnose from a log line?
-  (e.g., "qu: tcp connect: {e}" is good; "operation failed" is not)
-- Is there unintended coupling between driver crates that should be
-  independent? (e.g., driver-qu importing types from driver-mpc)
-- Any dead code, redundant logic, or clippy-level issues?
-- Were any features, config options, or feature gates described in the
-  plan but absent from the implementation? This is the highest-value
-  check — plans often specify build configuration that gets lost.
-
-### Test Coverage
-
-**Property tests are the highest-priority check.**
-
-- For any module that parses, encodes, or transforms data: are there
-  property tests? If not, flag this as a gap.
-- Do fixture-gated tests use `fixture_or_skip!` from
-  `project_core::testing` (return early when fixture is absent, don't
-  panic, don't `#[ignore]`)?
-- What edge cases do the tests miss? Be specific — "what happens if the
-  TCP connection drops mid-NRPN" is useful; "more tests would be good"
-  is not.
-
-{IF plan exists:}
-### Plan Conformance
-
-- Walk each task (T1, T2, ...) and each row in the Verification table:
-  was it implemented?
-- For each planned test, does a corresponding test exist in the diff?
-- Is there code in the diff that wasn't in the plan? Justified emergent
-  requirement or undocumented scope creep?
-{END IF}
-
-### Risks
-
-- TODOs, stubs, or placeholder implementations?
-- Could any change break existing functionality in other crates?
-- Security: path traversal in file operations? Command injection in SSH
-  exec calls? Unsanitized input passed to shell commands?
-- New dependencies justified and maintained?
-
-### Recommendations
-
-Separate into two lists:
-
-**Must fix before push:**
-- Issues that violate conventions, break tests, or introduce bugs.
-
-**Follow-up (future work):**
-- Improvements that are acceptable now but should be tracked.
-
-## Output format
-
-Structure your review as markdown with the H3 sections above. Be direct
-and specific. Cite file paths and line numbers. Keep the total review under
-400 lines. Prioritize by impact.
-~~~
-
-## Step 5: Place the output
-
-Append (never overwrite) a dated section to the already-existing
-`doc/reviews/review-NNNNN.md`, below the `## Summary` and any prior
-review rounds:
-
-```markdown
-## Local review (YYYY-MM-DD)
-
-**Branch:** <branch>
-**Commits:** <count> (origin/main..<branch>)
-**Reviewer:** Claude (sonnet, independent)
-
----
-
-{reviewer output}
-```
-
-## Step 6: Triage and apply auto-fixable items
-
-For each item in the reviewer's **Must fix before push** and
+For each item in the codex review's **Must fix before push** and
 **Follow-up (future work)** sections, classify into exactly one
 bucket — same heuristic as `/pr-watch`:
 
@@ -311,12 +152,12 @@ If either fails:
 - If the commit still fails: leave the working tree dirty so the
   user can investigate. Surface the failure in the report.
 
-**Do not loop `/pr-review` recursively.** One pass of auto-fixes
-is the contract — the agent applies what it confidently can, then
-hands off. The user can re-run `/pr-review` for another pass if
-they want one.
+**Do not loop `/pr-review` recursively.** One pass of auto-fixes is
+the contract — the agent applies what it confidently can, then hands
+off. The user can re-run `/pr-review` for another pass if they want
+one.
 
-## Step 7: Report and hand off
+## Step 5: Report and hand off
 
 Print a structured summary, ≤ 15 lines:
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -50,11 +50,14 @@ Refresh the ref and confirm the branch has diverged:
 
 ```
 git fetch --quiet origin main
-git diff origin/main...HEAD >/dev/null && echo "no diff to review" || true
+if git diff --quiet origin/main...HEAD; then
+  echo "no diff to review" && exit 1
+fi
 ```
 
-If `git diff --quiet origin/main...HEAD` exits 0, abort — there's
-nothing to review.
+`git diff --quiet` exits 0 when there is no diff — that's the abort
+condition. Plain `git diff` always exits 0 on a successful run and
+would not detect divergence.
 
 **Verify the review file exists.** `pr_review.sh` appends to a file
 created by TDD step 7; it never creates the file itself. Get its

--- a/.github/instructions/docs-review.instructions.md
+++ b/.github/instructions/docs-review.instructions.md
@@ -10,59 +10,109 @@ They narrow Copilot's review voice for prose content. Source code
 under `crates/` is reviewed under the default (strict) voice; nothing
 here relaxes that.
 
+## Scope exclusion: `doc/reviews/review-*.md`
+
+These files are an audit trail. They accumulate the verdict from
+codex (Tier 1 local review), the GitHub Copilot review (Tier 2
+post-push), human review comments, and reply mirrors — the discussion
+*about* the PR, not the PR's own work product. Commenting on the
+audit trail is noise: it's a record of decisions already made, not a
+doc that asks for review.
+
+**If the file matches `doc/reviews/review-*.md` (e.g.
+`review-00017.md`): surface zero findings.** Skip every check below.
+Return without comment.
+
+(`doc/reviews/calibration.md`, `doc/reviews/review-00000.md` and any
+future non-`review-NNNNN.md` file in `doc/reviews/` remain in scope
+under the rules below — they are working docs, not the audit trail.)
+
 ## What to flag
 
-- **Factual errors.** A formula that computes the wrong quantity, a
-  claim about the code that doesn't match what the code does, a
-  line-number reference that points at the wrong site, a broken
-  cross-link.
-- **Ambiguity that could mislead a reader.** Undefined variables in a
-  formula (e.g., `SNR` without saying whether it's in dB or linear),
-  a statement that could be read two ways where only one is correct.
-- **Contradictions within the PR.** A code snippet that disagrees with
-  the prose directly above or below it; a summary table whose values
-  don't match the per-entry detail tables.
-- **Stale content the PR should have updated.** If the PR claims to
-  fix an item in a catalog, but the catalog's top-level summary still
-  lists the item as unresolved, flag the summary.
+The bar for surfacing a finding on a `doc/` markdown file is high.
+A finding must do at least one of:
+
+  1. **Identify a factual error a reader would otherwise act on.**
+     A wrong formula, a claim about the code that doesn't match what
+     the code does, a line-number reference that points at the wrong
+     site, a broken cross-link to a real file.
+  2. **Resolve an ambiguity that could mislead a reader on
+     non-trivial subject matter.** Units missing on a quantity (`SNR`
+     without saying whether it's in dB or linear), an identifier
+     defined two ways, a statement that could be read two ways where
+     only one is correct.
+  3. **Catch a contradiction within the PR.** A code snippet that
+     disagrees with the prose directly above or below it; a summary
+     table whose values don't match the per-row detail tables. A PR
+     that breaks an established convention in the file it touches
+     (the convention is the contract; breaking it is a contradiction).
+  4. **Catch stale content the PR claims to update but didn't.** A
+     catalog whose top-level summary still lists an item the PR
+     removed. A doc-comment edit that misses the matching ToC entry.
+  5. **Plan §Review / Retrospective / Conclusion claims that explain
+     away a relaxation.** When reviewing files under `doc/plans/`,
+     the author's retro section is the highest-value ratification
+     trap. Treat sentences like "all N tests pass under this shape",
+     "tolerated via monotone-with-equality", "the test rename is
+     fine because…", "the deferred case is structural and doesn't
+     matter" as **bullshit until proven otherwise**. Verify every
+     relaxation claim against the type / API the PR diff still ships:
+
+       - Was the type declaration weakened to match the relaxation?
+         If not, escalate `must-fix` — soundness gap, not test
+         deviation.
+       - Does "all N proptests pass" mean coverage of the original
+         contract, or of a renamed weaker predicate? If the latter,
+         name the gap.
+       - Does a "deferred for follow-up" line correspond to a tracked
+         issue or just a sentence the author hopes the reviewer will
+         nod at?
+
+If a finding does none of these, **do not surface it**. Default to
+surfacing nothing.
 
 ## What to skip
 
 - **Single-word style preferences.** British vs American spelling
   variants where both are standard English (`parameterise` /
-  `parameterize`, `behaviour` / `behavior`) — do not flag unless the
-  file already establishes a consistent convention and this PR breaks
-  it.
+  `parameterize`, `behaviour` / `behavior`). The author's choice
+  stands.
+- **Punctuation, spacing, and formatting preferences** that don't
+  change the meaning. `±5 s` vs `0 to -5 s`, hyphenated vs
+  unhyphenated compound, en-dash vs em-dash, sentence vs title case
+  in headings.
 - **Comment-style nits in illustrative code snippets.** Rust snippets
   in docs are illustrations, not `use` statements a reader is expected
   to paste verbatim. A locator comment like `// my-crate::module`
-  communicates the same thing as `// my_crate::module`; prefer
-  whichever is already used consistently in the file.
+  communicates the same thing as `// my_crate::module`.
 - **Pre-existing patterns on unchanged lines.** If the PR touches file
-  X and a pattern the reviewer would otherwise flag (missing `crates/`
-  path prefix, hyphenated crate name, inconsistent formatting, etc.)
-  also appears on lines the PR did *not* modify in file X, do not flag
-  it. Those are concerns for a separate cleanup PR.
-- **Symmetry / punctuation preferences** (e.g., `±5 s` vs `0 to -5 s`)
-  unless the notation actually misrepresents the underlying quantity.
+  X and a pattern the reviewer would otherwise flag also appears on
+  lines the PR did *not* modify, do not flag it. Those are concerns
+  for a separate cleanup PR.
+- **Anything that reduces to "I'd phrase this differently."** Phrasing
+  belongs to the author.
+
+## Severity
+
+**There is no `nit:` tier.** If a finding doesn't meet the §What to
+flag bar, it doesn't get surfaced — full stop. Style and punctuation
+findings are out of scope.
+
+Findings that meet the bar are **must-fix**: would cause a reader to
+misunderstand the system, is demonstrably wrong on the current
+codebase, contradicts the PR's own claims, or ratifies a §Review
+that the diff doesn't back up.
+
+Plan §Review skepticism findings (category 5 above) are always
+must-fix even when the prose itself reads cleanly — they are
+substantive findings about whether the doc is honest about the diff.
 
 ## How to batch
 
-- **One comment per file for trivial nits.** If a file has two or more
-  small nits (missing prefixes, spelling, formatting), combine them
-  into a single inline comment citing each line number, rather than
-  opening a separate thread per nit. Separate threads force the author
-  to reply to each one individually and inflate review rounds.
-- **Substantive findings keep their own thread.** Factual errors,
-  contradictions, and ambiguities large enough to change a reader's
-  understanding remain as their own top-level comments.
+If a single file accumulates multiple substantive findings, combine
+them into a single inline comment citing each line number, rather
+than opening a separate thread per finding. The author's review-time
+budget is finite — preserve it for substantive matters.
 
-## Severity calibration
-
-- **Must-fix:** would cause a reader to misunderstand the system, or
-  is demonstrably wrong on the current codebase.
-- **Nit (optional):** stylistic or cosmetic. Prefix the comment with
-  `nit:` so the author can skim past; a reply of "deferred" closes
-  the thread without a code change.
-- Do not surface nits without the `nit:` prefix. The prefix is how
-  the author triages batches quickly.
+A reasonable expectation: most `doc/` PRs surface zero findings. The
+default outcome of this review is silence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,46 @@ lifecycle and the `/pr-watch` loop — useful when debugging an
 unexpected situation (stuck fix commit, loop that won't quit). The
 prose below is authoritative; the diagrams are derived views.
 
+### Review skepticism (read this every time)
+
+The reviewer's job is to verify the diff against the contracts the
+diff still ships, not to ratify the plan author's framing.
+
+**Trait-claim audit (do this first, before anything else).** For
+every new or changed `pub const` of a Galois-connection or
+order-theoretic type, every `iso!` / `conn_l!` / `conn_r!` /
+`compose!` / `triple!` invocation, and every non-derived `Lattice` /
+`Heyting` / `Boolean` / `Ord` / `PartialOrd` / `Hash` / `Eq` impl in
+the diff:
+
+  1. Quote the law the type or trait declaration claims.
+  2. Quote the closures or arms in the impl.
+  3. State whether (1) and (2) are consistent.
+
+The audit log is mandatory output even when every item is
+consistent. "All consistent" with no log is a missed audit, not a
+clean audit.
+
+**Test-exception escalation.** Any test renamed with a relaxation
+suffix (`*_total`, `*_relaxed`, `*_partial`, `*_weak`), any "we use
+a weaker predicate", "this case is excluded", "saturates instead
+of", "deferred", or "exception" in the diff or the plan, means the
+author found the strong predicate fails. Until the type declaration
+was *also* weakened, the strong predicate is still what the type
+claims — that gap is `must-fix`, not a test deviation.
+
+**The plan §Review / Retrospective / Conclusion is presumed
+adversarial framing.** It is the highest-value ratification trap:
+the author has already thought about the diff and written down the
+sentence they want the reviewer to nod at. Treat every claim in
+those sections — "all N lib tests pass under this shape", "tolerated
+via monotone-with-equality", "the test rename is fine because…" —
+as **bullshit until proven otherwise** by going to the diff and
+checking. The plan is read *after* the cold review, not before.
+Anything in §Review that explains away a relaxation or a deferred
+case must be promoted to a must-fix audit unless the type
+declaration was also weakened to match.
+
 ### Tier 1 — Local Review (pre-push)
 
 The coding agent makes atomic commits as it works. Commits can be as

--- a/doc/plans/plan-2026-05-07-04.md
+++ b/doc/plans/plan-2026-05-07-04.md
@@ -1,0 +1,201 @@
+# Plan 04 — Port the connections review-prompt sharpening upstream
+
+## Goal
+
+Land the §Review-skepticism rule, the trait-claim audit, the
+test-exception escalation rule, and the `doc/reviews/review-*.md`
+Copilot scope-exclusion in `template-rust` so siblings inherit them
+through the normal port mechanism. Also kill the Claude-side
+subagent path in `/pr-review` so the agent has zero authoring role
+in how the diff is handed off for review — codex is the reviewer.
+
+## Why now
+
+The `connections` repo just landed MR !71 retargeting its review
+prompts after MR !70 shipped a P1 soundness bug both Claude reviewers
+ratified (a float `iso!` claiming a `<=` Galois law the impl violated
+on NaN; the plan's §Review framed it as a "test deviation" and both
+reviewers nodded). The fix is portable: anywhere a reviewer reads a
+plan-author retro before the diff is a place this trap can spring.
+`template-rust` is the upstream for `agogo`, `mcp-live`, `riffgrep`,
+`stdio-core`, `stdio`, and `adat` — landing the change here is
+six-for-the-price-of-one when the workflow port catches each sibling
+up.
+
+Two sharpenings on top of the connections version:
+
+1. **Agent has no say in the review handoff.** The Claude
+   `/pr-review` command currently spawns a Claude subagent whose
+   prompt the orchestrator builds from scratch — exactly the
+   shape-your-own-review failure mode. Replace with a thin shim that
+   invokes `scripts/pr_review.sh` (which delegates to codex). Codex
+   loads `AGENTS.md` + `doc/reviews/calibration.md` itself; the
+   orchestrator passes nothing.
+2. **Reviewer must distrust the plan §Review.** The plan author's
+   retro is the highest-value ratification trap. AGENTS.md (codex's
+   system prompt) and `docs-review.instructions.md` (Copilot's prose
+   prompt) both get an explicit rule: treat §Review / Retrospective /
+   Conclusion as **bullshit until proven otherwise**. Verify every
+   relaxation claim against the type the diff still ships.
+
+## Dependency Graph
+
+```
+T1 plan + worktree (this commit)
+  ├─ T2 AGENTS.md  ── §Review-skepticism subsection
+  ├─ T3 calibration.md  ── Patterns 9 and 10
+  ├─ T4 .claude/commands/pr-review.md  ── kill subagent path
+  ├─ T5 .github/instructions/docs-review.instructions.md
+  │     ── exclude review-NNNNN.md, raise the bar, drop nit tier
+  └─ T6 scripts/pr_review.sh  ── prompt-fingerprint banner
+```
+
+## Tasks
+
+### T1 — Plan + worktree
+
+- Worktree: `../template-rust.plan-2026-05-07-04` off `origin/main`
+  (`4e1c3f0`).
+- Branch: `plan/2026-05-07-04`.
+- Plan file: this document.
+
+### T2 — AGENTS.md §Review-skepticism
+
+Append a `### Review skepticism (read this every time)` subsection
+under `## Code Review Workflow`, ahead of Tier-1. Codex auto-loads
+AGENTS.md as its system prompt; placing the rule here is what makes
+it bind on every codex review.
+
+Three rules:
+- **Trait-claim audit** — quote the law, quote the impl, state
+  consistency. Mandatory log even when consistent.
+- **Test-exception escalation** — relaxation suffix or "weaker
+  predicate" prose without a matching declaration weakening is
+  must-fix.
+- **§Review presumed adversarial** — the plan author's retro is
+  read after the cold review, not before, and is presumed bullshit
+  until verified.
+
+### T3 — calibration.md Patterns 9 and 10
+
+- **Pattern 9** — type claims a law the impl doesn't satisfy
+  (`iso!` + `*_total` rename); generalized off the `iso!` axis to
+  any contract claim.
+- **Pattern 10** — plan §Review pre-frames the bug as a "test
+  deviation"; the reviewer refuses to ratify the framing.
+
+### T4 — `.claude/commands/pr-review.md`
+
+Replace the 350-line subagent-orchestrating playbook with a thin
+shim:
+- Step 0: autosquash fixups (keep)
+- Step 1: prerequisite checks (keep — collapsed)
+- Step 2: invoke `scripts/pr_review.sh` (new — single-line action)
+- Step 3: read back the appended section verbatim (new)
+- Step 4: triage / auto-fix (kept from old Step 6)
+- Step 5: report and hand off (kept from old Step 7)
+
+Delete the entire `### Reviewer voice and calibration` and
+`### Reviewer prompt template` blocks. They exist only to brief a
+Claude subagent and they will rot — codex doesn't read them.
+
+The new file's intro spells out the orchestrator-not-reviewer
+contract explicitly. The orchestrator authors no prompt, picks no
+model, gathers no context.
+
+### T5 — `.github/instructions/docs-review.instructions.md`
+
+Three structural changes:
+
+**(a) Scope exclusion for `doc/reviews/review-*.md`.** The audit
+trail is not a doc that asks for review. New top-level section
+under the title: surface zero findings on these files; skip every
+check. `calibration.md` and `review-00000.md` remain in scope.
+
+**(b) Raise the bar on remaining docs.** Rewrite `## What to flag`
+to lead with a hard four-category bar (factual error, ambiguity,
+contradiction, stale content). Default outcome is silence.
+
+**(c) Drop the `nit:` tier entirely.** No more style nits, no more
+batched-nit allowance. Style preferences belong to the author.
+Findings that meet the bar are must-fix.
+
+Add the §Plan-doc skepticism rule as category 5 under §What to
+flag — mirror of the AGENTS.md rule, scoped to `doc/plans/`.
+
+### T6 — `scripts/pr_review.sh` fingerprint banner
+
+Before `codex review`, compute `git hash-object` of `AGENTS.md` and
+`doc/reviews/calibration.md`; print them in the appended local-
+review section so a review can be traced back to its prompt
+version. Belt-and-suspenders for prompt-engineering iteration.
+
+## Verification
+
+This is a prompt-engineering change. None of the verification is a
+proptest.
+
+### Properties (must pass)
+
+| Property | Module | Invariant |
+|----------|--------|-----------|
+| N/A | — | No production code change; verification is empirical |
+
+### Spot checks
+
+| Check | Assertion |
+|-------|-----------|
+| `cargo fmt --all -- --check` | No formatting drift on the editable surface (no Rust files changed) |
+| `cargo test --workspace` | Workspace tests pass; review-prompt edits don't regress anything |
+| `python3 -m unittest` | Workflow harness tests pass against the edited `pr_review.sh` |
+| `scripts/pr_review.sh --check` | Prerequisite check still passes (codex / gh / pr_report.py reachable) |
+| `scripts/check_pii.sh` | No PII landed in the new prose |
+| Manual: codex auto-loads AGENTS.md | `codex review --base origin/main` on this branch produces a review that mentions a trait-claim audit log; if the new AGENTS.md text didn't bind, tighten it |
+
+### Build gates
+
+- `cargo fmt --all -- --check`
+- `cargo test --workspace`
+- `python3 -m unittest`
+- `scripts/check_pii.sh`
+- `scripts/check_layers.sh` (if applicable to touched layers — we
+  edit no Rust)
+- `scripts/pr_review.sh --check`
+
+## Coordination with the parallel agent
+
+`plan/2026-05-07-02` (cross-repo workflow port to siblings) and
+`plan/2026-05-07-03` (workflow review fixes back-port) are both
+mid-flight. The five files this plan touches do not overlap with
+either of those branches' scope — the §Review-skepticism subsection
+in AGENTS.md is new prose added under `## Code Review Workflow`,
+the new patterns are appended to the end of `calibration.md`, the
+`.claude/commands/pr-review.md` rewrite is total but unrelated to
+sibling distribution, the `docs-review.instructions.md` restructure
+adds new sections, and the `pr_review.sh` change is a single
+fingerprint-banner block. Merge order does not matter; whoever
+lands second rebases without conflict in expectation, and resolves
+any incidental conflict in favor of preserving both edits.
+
+Per-sibling exposure rides whichever follow-up port commit lands
+the post-2026-05-07-02 surface — same five files cherry-picked on
+top, no per-sibling plan needed unless a sibling wants to deviate.
+
+## Deferred
+
+- **Sibling-repo PRs.** This plan does not open per-sibling PRs;
+  they ride the parallel agent's distribution.
+- **Lint enforcement.** A `*_total` / `*_relaxed` test-rename grep
+  asserting a matching type-level weakening is the structural fix,
+  but premature without a real-review corpus.
+- **Plan-template change.** Forcing every plan §Review section to
+  declare type-level relaxations alongside their declaration changes
+  is the author-side counterpart, but the §Review-skepticism rule
+  on the reviewer side already mitigates the failure mode.
+- **CI gating on codex review.** Stays advisory. Turning the bot
+  into a merge blocker amplifies the ratification failure mode this
+  plan exists to mitigate.
+
+## Review
+
+(To be filled in after implementation per AGENTS.md TDD step 6.)

--- a/doc/reviews/calibration.md
+++ b/doc/reviews/calibration.md
@@ -189,3 +189,68 @@ the sign convention through two definitions and shows the contradiction.
 *should* agree but don't. Names the specific parameter space where they
 diverge, and explains the observable consequence. This is the kind of
 cross-system bug that unit tests per-system would never catch.
+
+---
+
+## Pattern 9: Type claims a law the impl doesn't satisfy
+
+> **File:** `crates/foo-core/src/byte/four.rs`
+>
+> **Diff context:**
+> ```
+> +crate::iso! {
+> +    pub F032OBYT : f32 => Bytes<4> {
+> +        forward: f32_to_obyt,
+> +        back:    obyt_to_f32,
+> +    }
+> +}
+> +// In tests:
+> +proptest_battery_iso_total!(F032OBYT, arb_f32(), arb_byte4());
+> ```
+>
+> **Comment:** `iso!` declares `F032OBYT: ConnK<f32, Bytes<4>>` — a
+> both-sided Galois connection over `<=`. The proptest battery was
+> renamed `*_iso_total` (`f32::total_cmp`) because the `<=`
+> predicate fails on bytes that decode to NaN. The rename masks a
+> type-level violation: `iso!` still claims the `<=` law, which the
+> impl doesn't satisfy. Either weaken the declaration to `conn_l!`
+> over a NaN-aware host (e.g. a `NonNan` newtype or a totalOrder
+> byte-newtype), or drop the float Conns until a sound shape exists.
+
+**Why this is good:** Catches the real bug — a *type-system claim*
+the impl doesn't satisfy — by reading the type declaration and the
+test rename together. Generalizes off the `iso!` axis to any
+contract claim: a `Lattice` impl with a `meet` that isn't idempotent
+on a sentinel row, an `Ord` impl that isn't total on empty strings,
+a `Hash` / `Eq` pair that disagrees on NaN. The reviewer's job is
+to read the type the diff still ships, not the predicate the test
+was renamed to.
+
+---
+
+## Pattern 10: Plan §Review pre-frames the bug as a "test deviation"
+
+> **Plan §Review excerpt:**
+> ```
+> f32 Galois harnesses use `total_cmp` because the classical
+> predicate fails on NaN. All N proptests pass under this shape.
+> ```
+>
+> **Diff context:** the `iso!` declaration is unchanged; the
+> proptest battery is the only thing that moved.
+>
+> **Comment:** This §Review note is the ratification trap. The
+> author has framed the relaxation as a property of the *test*,
+> but the *type* still claims the unrelaxed law. Promoting this
+> to must-fix: name the type-level claim, name what the impl
+> actually satisfies, and require either the declaration to weaken
+> or the float Conns to drop. "All proptests pass under this shape"
+> is a fact about the harness, not about the type.
+
+**Why this is good:** Refuses to nod at §Review framing. The plan
+author's retro is presumed adversarial — the reviewer's job is to
+go to the diff and verify, not to accept the explanation. The "all
+N tests pass" sentence is particularly load-bearing: it sounds like
+coverage, but it's coverage of the weakened predicate, not the
+type's claim. The fix is the same whether the §Review excused it
+or not.

--- a/doc/reviews/review-00023.md
+++ b/doc/reviews/review-00023.md
@@ -1,0 +1,18 @@
+# PR #23 — Port connections review-prompt sharpening upstream
+
+## Summary
+
+- Add §Review-skepticism to AGENTS.md (codex's system prompt) and Patterns 9–10 to calibration.md so codex audits trait/contract claims, escalates `*_total`/`*_relaxed` test renames, and treats the plan §Review as adversarial framing rather than ratifying it.
+- Gut `.claude/commands/pr-review.md` (–225/+66): the Claude path is now a thin shim that runs `scripts/pr_review.sh` (which delegates to codex). The orchestrator authors no prompt, picks no model, and gathers no context — codex loads the contract files itself.
+- Tighten `.github/instructions/docs-review.instructions.md`: `doc/reviews/review-*.md` is off-limits (audit trail, not a doc that asks for review), the bar for other docs is raised to four hard categories with default-silence, the `nit:` tier is removed, and §Plan-doc skepticism lands as a fifth flag category. `scripts/pr_review.sh` now records an AGENTS.md / calibration.md fingerprint in each appended local-review section.
+
+## Test plan
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo test --workspace` (no Rust changed; ran for completeness via pre-commit/-push hooks across each commit)
+- [x] `python3 -m unittest discover -s tests` (4/4 pass)
+- [x] `scripts/check_pii.sh`
+- [x] `scripts/check_layers.sh`
+- [x] `scripts/pr_review.sh --check` (codex / gh / pr_report.py reachable)
+- [ ] Tier-2 smoke test: GitHub Copilot review on this PR exercises the new `docs-review.instructions.md` rules — verify it surfaces zero findings on `review-00023.md`, raises the bar on the other docs, and (on a future plan PR) catches a §Review-shaped ratification trap.
+- [ ] Manual smoke test: run `/pr-review` on a synthetic branch with an `iso!` whose closure breaks `<=` on NaN, a `*_total` proptest rename, and a §Review note explaining the rename — confirm codex flags the type-claim gap as must-fix.

--- a/doc/reviews/review-00023.md
+++ b/doc/reviews/review-00023.md
@@ -16,3 +16,59 @@
 - [x] `scripts/pr_review.sh --check` (codex / gh / pr_report.py reachable)
 - [ ] Tier-2 smoke test: GitHub Copilot review on this PR exercises the new `docs-review.instructions.md` rules — verify it surfaces zero findings on `review-00023.md`, raises the bar on the other docs, and (on a future plan PR) catches a §Review-shaped ratification trap.
 - [ ] Manual smoke test: run `/pr-review` on a synthetic branch with an `iso!` whose closure breaks `<=` on NaN, a `*_total` proptest rename, and a §Review note explaining the rename — confirm codex flags the type-claim gap as must-fix.
+
+<!-- gh-id: 4249740297 -->
+### copilot-pull-request-reviewer[bot] — COMMENTED ([2026-05-08 05:35 UTC](https://github.com/cmk/template-rust/pull/23#pullrequestreview-4249740297))
+
+## Pull request overview
+
+This PR ports and tightens the repository’s review workflow contracts so automated reviews are more skeptical of plan/§Review framing, and it simplifies the Claude `/pr-review` command to delegate Tier‑1 review execution to `scripts/pr_review.sh` (which runs `codex review`).
+
+**Changes:**
+- Add “Review skepticism” rules to `AGENTS.md` and extend `doc/reviews/calibration.md` with two new anti-ratification patterns.
+- Simplify `.claude/commands/pr-review.md` to an orchestrator shim that runs `scripts/pr_review.sh` rather than constructing/spawning a separate reviewer agent.
+- Tighten docs review instructions, including an explicit scope exclusion for `doc/reviews/review-*.md`, and add a prompt fingerprint banner to `scripts/pr_review.sh`.
+
+### Reviewed changes
+
+Copilot reviewed 7 out of 7 changed files in this pull request and generated 2 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File | Description |
+| ---- | ----------- |
+| `scripts/pr_review.sh` | Appends a prompt fingerprint (AGENTS/calibration blob IDs) to the local review section for traceability. |
+| `doc/reviews/review-00023.md` | Adds the PR’s audit-trail entry (summary + test plan). |
+| `doc/reviews/calibration.md` | Adds Patterns 9–10 to calibrate reviewers against “type-claim vs relaxed test” and §Review framing traps. |
+| `doc/plans/plan-2026-05-07-04.md` | Adds the implementation plan describing the upstream port and verification steps. |
+| `AGENTS.md` | Adds a new “Review skepticism” subsection to strengthen reviewer obligations (audit, escalation, adversarial §Review framing). |
+| `.github/instructions/docs-review.instructions.md` | Raises the bar for doc findings, excludes `doc/reviews/review-*.md`, and adds plan §Review skepticism checks. |
+| `.claude/commands/pr-review.md` | Replaces the prior subagent-driven reviewer flow with a script-driven codex review workflow. |
+</details>
+
+
+
+
+
+
+<!-- gh-id: 3206503578 -->
+### Copilot on [`scripts/pr_review.sh:74`](https://github.com/cmk/template-rust/pull/23#discussion_r3206503578) (2026-05-08 05:35 UTC)
+
+The prompt fingerprint is computed after running `codex review`, but the comment says it's recording what codex "saw". To make the fingerprint reliably correspond to the exact prompt version used for the review (and match the stated intent), compute `agents_sha`/`calib_sha` before invoking `codex review` and then print them alongside the captured output.
+
+<!-- gh-id: 3206503595 -->
+### Copilot on [`.claude/commands/pr-review.md:53`](https://github.com/cmk/template-rust/pull/23#discussion_r3206503595) (2026-05-08 05:35 UTC)
+
+`git diff origin/main...HEAD` exits 0 even when there *are* changes (unless `--quiet/--exit-code` is used), so this snippet will incorrectly echo "no diff to review" on most branches. Use `git diff --quiet origin/main...HEAD` (or `git diff --exit-code ...`) for the divergence check so the instructions match the abort condition described below.
+
+
+<!-- gh-id: 3206552740 -->
+#### ↳ cmk ([2026-05-08 05:48 UTC](https://github.com/cmk/template-rust/pull/23#discussion_r3206552740))
+
+Fixed — moved the fingerprint compute above the codex invocation so the recorded SHAs are guaranteed to match the version codex loaded. Comment updated to match.
+
+<!-- gh-id: 3206553859 -->
+#### ↳ cmk ([2026-05-08 05:48 UTC](https://github.com/cmk/template-rust/pull/23#discussion_r3206553859))
+
+Fixed — replaced the snippet with the `--quiet` form that matches the abort prose below it. The wrong snippet would have echoed 'no diff to review' on every branch with changes.

--- a/scripts/pr_review.sh
+++ b/scripts/pr_review.sh
@@ -69,11 +69,22 @@ trap 'rm -f "$tmp"' EXIT
 # root, so use the supported base-review invocation.
 codex review --base origin/main >"$tmp"
 
+# Record which prompt files codex saw, so a review can be traced back
+# to its prompt version after AGENTS.md or calibration.md drift.
+agents_sha=$(git hash-object AGENTS.md 2>/dev/null || echo missing)
+if [ -f doc/reviews/calibration.md ]; then
+  calib_sha=$(git hash-object doc/reviews/calibration.md)
+else
+  calib_sha=missing
+fi
+
 {
   printf '\n## Local review (%s)\n\n' "$date"
   printf '**Branch:** %s\n' "$branch"
   printf '**Commits:** %s (origin/main..%s)\n' "$commits" "$branch"
-  printf '**Reviewer:** Codex (`codex review --base origin/main`)\n\n'
+  printf '**Reviewer:** Codex (`codex review --base origin/main`)\n'
+  printf '**Prompt fingerprint:** AGENTS.md=%s calibration=%s\n\n' \
+    "$agents_sha" "$calib_sha"
   printf '%s\n\n' '---'
   cat "$tmp"
   printf '\n'

--- a/scripts/pr_review.sh
+++ b/scripts/pr_review.sh
@@ -64,19 +64,21 @@ date=$(date +%F)
 tmp=$(mktemp)
 trap 'rm -f "$tmp"' EXIT
 
-# Codex CLI 0.125 rejects a custom prompt together with --base, even
-# though help advertises both. AGENTS.md is discovered from the repo
-# root, so use the supported base-review invocation.
-codex review --base origin/main >"$tmp"
-
-# Record which prompt files codex saw, so a review can be traced back
-# to its prompt version after AGENTS.md or calibration.md drift.
+# Record which prompt files codex sees, *before* invoking it, so the
+# fingerprint is guaranteed to match the version codex loads. (If we
+# computed after the run, a concurrent edit between codex's read and
+# our hash would silently desync.) This is the version codex saw.
 agents_sha=$(git hash-object AGENTS.md 2>/dev/null || echo missing)
 if [ -f doc/reviews/calibration.md ]; then
   calib_sha=$(git hash-object doc/reviews/calibration.md)
 else
   calib_sha=missing
 fi
+
+# Codex CLI 0.125 rejects a custom prompt together with --base, even
+# though help advertises both. AGENTS.md is discovered from the repo
+# root, so use the supported base-review invocation.
+codex review --base origin/main >"$tmp"
 
 {
   printf '\n## Local review (%s)\n\n' "$date"


### PR DESCRIPTION
- Add §Review-skepticism to AGENTS.md (codex's system prompt) and Patterns 9–10 to calibration.md so codex audits trait/contract claims, escalates `*_total`/`*_relaxed` test renames, and treats the plan §Review as adversarial framing rather than ratifying it.
- Gut `.claude/commands/pr-review.md` (–225/+66): the Claude path is now a thin shim that runs `scripts/pr_review.sh` (which delegates to codex). The orchestrator authors no prompt, picks no model, and gathers no context — codex loads the contract files itself.
- Tighten `.github/instructions/docs-review.instructions.md`: `doc/reviews/review-*.md` is off-limits (audit trail, not a doc that asks for review), the bar for other docs is raised to four hard categories with default-silence, the `nit:` tier is removed, and §Plan-doc skepticism lands as a fifth flag category. `scripts/pr_review.sh` now records an AGENTS.md / calibration.md fingerprint in each appended local-review section.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (no Rust changed; ran for completeness via pre-commit/-push hooks across each commit)
- [x] `python3 -m unittest discover -s tests` (4/4 pass)
- [x] `scripts/check_pii.sh`
- [x] `scripts/check_layers.sh`
- [x] `scripts/pr_review.sh --check` (codex / gh / pr_report.py reachable)
- [ ] Tier-2 smoke test: GitHub Copilot review on this PR exercises the new `docs-review.instructions.md` rules — verify it surfaces zero findings on `review-00023.md`, raises the bar on the other docs, and (on a future plan PR) catches a §Review-shaped ratification trap.
- [ ] Manual smoke test: run `/pr-review` on a synthetic branch with an `iso!` whose closure breaks `<=` on NaN, a `*_total` proptest rename, and a §Review note explaining the rename — confirm codex flags the type-claim gap as must-fix.
