### PR TITLE
Delegate pr-review path selection

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -59,24 +59,14 @@ fi
 condition. Plain `git diff` always exits 0 on a successful run and
 would not detect divergence.
 
-**Verify the review file exists.** `pr_review.sh` appends to a file
-created by TDD step 7; it never creates the file itself. Get its
-path:
-
-- If a PR already exists for this branch:
-  ```
-  scripts/pr_report.py path "$(gh pr view --json number --jq .number)"
-  ```
-- Otherwise (the normal pre-push case):
-  ```
-  scripts/pr_report.py path
-  ```
-
-`pr_report.py path` predicts (or accepts) the PR number and emits the
-zero-padded filename. Confirm the returned path exists **and contains
-a `## Summary` section**. If either is missing, abort and tell the
-user to run TDD step 7. Do not create the file yourself — the PR body
-belongs in step 7's commit, not as a post-hoc fabrication.
+Review-file selection and validation belong to `scripts/pr_review.sh`.
+Do not run a separate `scripts/pr_report.py path` existence gate in
+this command. The predicted next PR number can drift between TDD step 7
+and this transition; the script first looks for exactly one
+branch-local `doc/reviews/review-NNNNN.md` in
+`git diff origin/main...HEAD`, then falls back to the predicted path.
+It also validates that the chosen file exists and contains `## Summary`.
+If that validation fails, surface the script's error and stop.
 
 ## Step 2: Run codex via scripts/pr_review.sh
 
@@ -101,7 +91,8 @@ yourself.
 ## Step 3: Read back the appended review section
 
 Capture the section codex appended to the review file so Step 4 can
-triage it. No interpretation, no summarization — pass it through
+triage it. Use the review path printed by `pr_review.sh` after a
+successful run. No interpretation, no summarization — pass it through
 verbatim to the triage logic. (`tail` from a recorded byte-offset, or
 re-read the file and slice from the last `## Local review` heading
 onward.)

--- a/doc/plans/plan-2026-05-08-01.md
+++ b/doc/plans/plan-2026-05-08-01.md
@@ -1,0 +1,62 @@
+# Plan 01 - Delegate pr-review Path Selection
+
+## Goal
+Make Claude Code's `/pr-review` command let `scripts/pr_review.sh` own review-file selection so branch-local review files survive PR-number drift.
+
+## Dependency Graph
+
+```text
+T1 -> T2 -> T3
+```
+
+## Tasks
+
+### T1 - Confirm the split-brain prerequisite
+
+- Problem or motivation: `scripts/pr_review.sh` can recover when `scripts/pr_report.py path` predicts a newer review number, but `.claude/commands/pr-review.md` still tells Claude to abort before the script runs.
+- Solution / implementation approach: compare the command prose with the shell script's branch-local review-file scan.
+- Types or API surface: no runtime API change.
+
+### T2 - Make `/pr-review` delegate review-file validation
+
+- Problem or motivation: two independent validators drifted, and the command wrapper's older validator masks the script's newer fallback.
+- Solution / implementation approach: remove the predicted-path existence check from `.claude/commands/pr-review.md`; keep only high-level prerequisite guidance and state that the script validates the review file and `## Summary`.
+- Types or API surface: `.claude/commands/pr-review.md` only.
+
+### T3 - Verify the workflow contract
+
+- Problem or motivation: this is workflow text, so the failure mode is stale instructions rather than Rust behavior.
+- Solution / implementation approach: run focused text/script checks that prove the command points to the script and the script remains syntactically valid.
+- Types or API surface: no runtime API change.
+
+## Verification
+
+### Properties (must pass)
+
+No proptest properties apply; this sprint changes a Claude command document, not a parser, encoder, or data transform.
+
+| Property | Module | Invariant |
+|----------|--------|-----------|
+
+### Spot checks
+
+| Check | Assertion |
+|-------|-----------|
+| `rg` command-text check | `.claude/commands/pr-review.md` no longer tells Claude to abort solely because the predicted `pr_report.py path` file is missing |
+| `bash -n scripts/pr_review.sh` | local-review script remains shell-syntax clean |
+| `python3 -m unittest tests.test_pr_review` | existing branch-local review-file fallback coverage still passes |
+
+### Build gates
+
+- `cargo build` - no errors if run for the final branch
+- `cargo test` - all pass if run for the final branch
+- `cargo clippy --all-targets` - no errors if run for the final branch
+- End-to-end scenario: a branch with committed `review-00004.md` can run `/pr-review` after the next predicted path advances to `review-00005.md`; the script, not Claude's pre-check, chooses the branch-local file.
+
+## Deferred
+
+Filled in at sprint close.
+
+## Review
+
+Filled in at sprint close.

--- a/doc/plans/plan-2026-05-08-01.md
+++ b/doc/plans/plan-2026-05-08-01.md
@@ -55,8 +55,13 @@ No proptest properties apply; this sprint changes a Claude command document, not
 
 ## Deferred
 
-Filled in at sprint close.
+None.
 
 ## Review
 
-Filled in at sprint close.
+- No `#[ignore]`d properties.
+- Design deviations from the plan: none.
+- Drift caught:
+  - `.claude/commands/pr-review.md:62` - workflow instruction drift - fixed here; the command still duplicated the old predicted-path prerequisite after `scripts/pr_review.sh` learned to prefer a branch-local review file.
+- Recommendations:
+  - Keep review-file discovery centralized in `scripts/pr_review.sh`; command docs should describe the script contract rather than reimplement its path selection.

--- a/doc/reviews/review-00025.md
+++ b/doc/reviews/review-00025.md
@@ -1,0 +1,23 @@
+# PR #25 - Delegate pr-review Path Selection
+
+## Summary
+
+This PR fixes the Claude Code `/pr-review` command wrapper so it no longer aborts before `scripts/pr_review.sh` can apply its branch-local review-file fallback.
+
+The shell script already handles PR-number drift by scanning `git diff origin/main...HEAD` for exactly one committed `doc/reviews/review-NNNNN.md` before falling back to the newly predicted path. The command file still told Claude to predict the path itself and abort if that file was missing, which masked the script fallback.
+
+Changes:
+
+- Remove the duplicated predicted-path existence gate from `.claude/commands/pr-review.md`.
+- Document that review-file selection and `## Summary` validation belong to `scripts/pr_review.sh`.
+- Tell the command to use the path printed by the script when reading back the appended local-review section.
+
+Verification:
+
+- `bash -n scripts/pr_review.sh`
+- `python3 -B -m unittest tests.test_pr_review`
+- `rg` check confirmed the old abort wording is gone and the branch-local fallback wording is present.
+- `scripts/pr_review.sh --check`
+- `git diff --check`
+- `cargo test --workspace`
+- `cargo clippy --all-targets -- -D warnings`


### PR DESCRIPTION
This PR fixes the Claude Code `/pr-review` command wrapper so it no longer aborts before `scripts/pr_review.sh` can apply its branch-local review-file fallback.

The shell script already handles PR-number drift by scanning `git diff origin/main...HEAD` for exactly one committed `doc/reviews/review-NNNNN.md` before falling back to the newly predicted path. The command file still told Claude to predict the path itself and abort if that file was missing, which masked the script fallback.

Changes:

- Remove the duplicated predicted-path existence gate from `.claude/commands/pr-review.md`.
- Document that review-file selection and `## Summary` validation belong to `scripts/pr_review.sh`.
- Tell the command to use the path printed by the script when reading back the appended local-review section.

Verification:

- `bash -n scripts/pr_review.sh`
- `python3 -B -m unittest tests.test_pr_review`
- `rg` check confirmed the old abort wording is gone and the branch-local fallback wording is present.
- `scripts/pr_review.sh --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`