### PR TITLE
Batch tree PII scans

### DIFF
--- a/doc/plans/plan-2026-05-08-02.md
+++ b/doc/plans/plan-2026-05-08-02.md
@@ -56,8 +56,13 @@ No proptest properties apply; this sprint changes a workflow script and its proc
 
 ## Deferred
 
-Filled in at sprint close.
+None.
 
 ## Review
 
-Filled in at sprint close.
+- No `#[ignore]`d properties.
+- Design deviations from the plan: none.
+- Drift caught:
+  - `scripts/check_pii.sh:129` - workflow performance drift - fixed here; tree mode spawned one `git grep` per tracked file instead of scanning the tree in one process.
+- Recommendations:
+  - Keep tree-mode history/CI scans batched; use tests that observe process shape when a performance bug is specifically about process count.

--- a/doc/plans/plan-2026-05-08-02.md
+++ b/doc/plans/plan-2026-05-08-02.md
@@ -1,0 +1,63 @@
+# Plan 02 - Batch Tree PII Scans
+
+## Goal
+Make `scripts/check_pii.sh --tree` scan a committed tree with one `git grep` invocation instead of spawning one process per tracked file.
+
+## Dependency Graph
+
+```text
+T1 -> T2 -> T3
+```
+
+## Tasks
+
+### T1 - Confirm the tree-mode process shape
+
+- Problem or motivation: downstream review identified that `--tree` mode loops over every tracked file and runs `git grep` once per file, which makes history/CI scans O(files) in process startup overhead.
+- Solution / implementation approach: inspect the current tree-mode loop and preserve the existing output and allowlist semantics while changing only the scan strategy.
+- Types or API surface: no CLI change.
+
+### T2 - Batch tree scanning
+
+- Problem or motivation: per-file `git grep` is avoidable because Git can search the whole tree with pathspec excludes in one invocation.
+- Solution / implementation approach: run one NUL-delimited `git grep -z -n -I -E "$alt" "$tree_ref" -- .` excluding `scripts/check_pii.sh` and `.pii-allow`, then post-process each matched content line through the existing allowlist filter.
+- Types or API surface: `scripts/check_pii.sh --tree <ref>` keeps the same report shape.
+
+### T3 - Cover process-count behavior
+
+- Problem or motivation: detection-only tests would not catch a regression back to one grep process per file.
+- Solution / implementation approach: add a unit test that wraps `git`, runs tree mode over multiple leaking files, and asserts exactly one `git grep` invocation while both leaks are reported.
+- Types or API surface: `tests/test_check_pii.py`.
+
+## Verification
+
+### Properties (must pass)
+
+No proptest properties apply; this sprint changes a workflow script and its process-count regression test, not a parser, encoder, or data transform.
+
+| Property | Module | Invariant |
+|----------|--------|-----------|
+
+### Spot checks
+
+| Check | Assertion |
+|-------|-----------|
+| `bash -n scripts/check_pii.sh` | PII scanner remains shell-syntax clean |
+| `python3 -B -m unittest tests.test_check_pii` | tree mode preserves detection, allowlist semantics, and one-grep batching |
+| `python3 -B -m unittest` | workflow script regression suite remains green |
+| `scripts/check_pii.sh --tree HEAD` | committed-tree scan remains clean on this branch |
+
+### Build gates
+
+- `cargo build` - no errors if run for the final branch
+- `cargo test` - all pass if run for the final branch
+- `cargo clippy --all-targets` - no errors if run for the final branch
+- End-to-end scenario: a committed tree with multiple matching files is scanned by one `git grep`, and each non-allowlisted match is still reported with `tree:path:line:content`.
+
+## Deferred
+
+Filled in at sprint close.
+
+## Review
+
+Filled in at sprint close.

--- a/doc/reviews/review-00026.md
+++ b/doc/reviews/review-00026.md
@@ -1,0 +1,23 @@
+# PR #26 - Batch Tree PII Scans
+
+## Summary
+
+This PR fixes `scripts/check_pii.sh --tree` so committed-tree scans run one `git grep` across the tree instead of spawning `git grep` once per tracked file.
+
+The CLI and report format stay the same. The scanner still excludes `scripts/check_pii.sh` and `.pii-allow`, and `.pii-allow` still filters matched content rather than file locations.
+
+Changes:
+
+- Replace the per-file `git ls-tree` / `git grep` loop with one NUL-delimited tree-wide `git grep`.
+- Preserve the existing `tree:path:line:content` report shape.
+- Add a regression that wraps `git` and asserts tree mode invokes `git grep` once while reporting multiple leaking files.
+
+Verification:
+
+- `bash -n scripts/check_pii.sh`
+- `python3 -B -m unittest tests.test_check_pii`
+- `python3 -B -m unittest`
+- `scripts/check_pii.sh --tree HEAD`
+- `git diff --check`
+- `cargo test --workspace`
+- `cargo clippy --all-targets -- -D warnings`

--- a/doc/reviews/review-00026.md
+++ b/doc/reviews/review-00026.md
@@ -21,3 +21,41 @@ Verification:
 - `git diff --check`
 - `cargo test --workspace`
 - `cargo clippy --all-targets -- -D warnings`
+
+<!-- gh-id: 4250890859 -->
+### copilot-pull-request-reviewer[bot] — COMMENTED ([2026-05-08 08:50 UTC](https://github.com/cmk/template-rust/pull/26#pullrequestreview-4250890859))
+
+## Pull request overview
+
+This pull request improves the performance of committed-tree PII scanning by changing `scripts/check_pii.sh --tree` from a per-file `git grep` loop to a single tree-wide `git grep` invocation, while keeping the CLI and report format stable.
+
+**Changes:**
+- Batch `--tree` scanning into one NUL-delimited `git grep` over the whole tree (with excludes preserved).
+- Preserve the existing `tree_ref:path:line:content` report output shape and allowlist semantics.
+- Add a Python regression test intended to assert `--tree` mode invokes `git grep` once while still reporting multiple leaking files.
+
+### Reviewed changes
+
+Copilot reviewed 4 out of 4 changed files in this pull request and generated 1 comment.
+
+| File | Description |
+| ---- | ----------- |
+| scripts/check_pii.sh | Replace per-file tree scanning with a single tree-wide `git grep -z` and post-process matches. |
+| tests/test_check_pii.py | Add a regression test that wraps `git` to count `git grep` invocations in `--tree` mode. |
+| doc/plans/plan-2026-05-08-02.md | Document the plan/verification steps for batching tree scans and process-count testing. |
+| doc/reviews/review-00026.md | Add the PR review audit entry (not reviewed for findings per repo guidelines). |
+
+
+
+
+
+<!-- gh-id: 3207518055 -->
+### Copilot on [`tests/test_check_pii.py:203`](https://github.com/cmk/template-rust/pull/26#discussion_r3207518055) (2026-05-08 08:50 UTC)
+
+The new regression test only checks that both filenames appear somewhere in stderr; it doesn’t assert that tree-mode produced two distinct `tree_ref:path:line:content` entries. A parsing bug in the NUL-delimited `git grep` output could concatenate records and still contain both filenames, letting the test pass while the report shape is wrong. Consider asserting that stderr contains separate lines matching `HEAD:leak_one.txt:` and `HEAD:leak_two.txt:` (and ideally their respective line numbers/content) to validate the multi-match parsing behavior in addition to the process-count behavior.
+
+
+<!-- gh-id: 3207533691 -->
+#### ↳ cmk ([2026-05-08 08:53 UTC](https://github.com/cmk/template-rust/pull/26#discussion_r3207533691))
+
+Fixed - the regression now asserts separate HEAD:leak_one.txt:1:path=... and HEAD:leak_two.txt:1:path=... report entries, so it verifies multi-match parsing as well as the one-grep process count.

--- a/scripts/check_pii.sh
+++ b/scripts/check_pii.sh
@@ -126,30 +126,31 @@ else
   load_tree_allow_patterns
 
   tree_report=''
-  while IFS= read -r -d '' f; do
-    case "$f" in
-      scripts/check_pii.sh|.pii-allow) continue ;;
-    esac
+  tree_matches=$(mktemp)
+  tree_errors=$(mktemp)
+  trap 'rm -f "$tree_matches" "$tree_errors"' EXIT
 
-    set +e
-    matches=$(git grep -I -n --no-color -h -E "$alt" "$tree_ref" -- "$f" 2>&1)
-    status=$?
-    set -e
-    if [ "$status" -eq 1 ]; then
-      continue
-    elif [ "$status" -ne 0 ]; then
-      echo "error: git grep failed while scanning tree $tree_ref:$f:" >&2
-      printf '%s\n' "$matches" >&2
-      exit 2
-    fi
-
-    while IFS= read -r match; do
-      line_no="${match%%:*}"
-      content="${match#*:}"
+  set +e
+  git grep -z -I -n --no-color -E "$alt" "$tree_ref" -- \
+    . ':(exclude)scripts/check_pii.sh' ':(exclude).pii-allow' \
+    >"$tree_matches" 2>"$tree_errors"
+  status=$?
+  set -e
+  if [ "$status" -eq 1 ]; then
+    :
+  elif [ "$status" -ne 0 ]; then
+    echo "error: git grep failed while scanning tree $tree_ref:" >&2
+    cat "$tree_errors" >&2
+    exit 2
+  else
+    while IFS= read -r -d '' location \
+      && IFS= read -r -d '' line_no \
+      && IFS= read -r content; do
+      path="${location#"$tree_ref:"}"
       [ -z "$(filter_allowed "$content")" ] && continue
-      tree_report+="    $tree_ref:$f:$line_no:$content"$'\n'
-    done <<< "$matches"
-  done < <(git ls-tree -r -z --name-only "$tree_ref" -- .)
+      tree_report+="    $tree_ref:$path:$line_no:$content"$'\n'
+    done < "$tree_matches"
+  fi
 
   if [ -n "$tree_report" ]; then
     report+="  $tree_ref:"$'\n'

--- a/tests/test_check_pii.py
+++ b/tests/test_check_pii.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -145,6 +147,61 @@ class CheckPiiTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 1)
             self.assertIn(home_path, result.stderr)
+
+    def test_tree_mode_invokes_one_git_grep_for_whole_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            repo = Path(raw)
+            home_path = "/Users/" + "alice" + "/project"
+            real_git = shutil.which("git")
+            self.assertIsNotNone(real_git)
+            git(repo, "init", "--initial-branch=main")
+            git(repo, "config", "user.name", "PII Test")
+            git(repo, "config", "user.email", "pii@example.invalid")
+
+            scripts = repo / "scripts"
+            scripts.mkdir()
+            script = scripts / "check_pii.sh"
+            script.write_text(CHECK_PII_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+            script.chmod(script.stat().st_mode | stat.S_IXUSR)
+            (repo / "README.md").write_text("safe\n", encoding="utf-8")
+            (repo / "leak_one.txt").write_text(f"path={home_path}/one\n", encoding="utf-8")
+            (repo / "leak_two.txt").write_text(f"path={home_path}/two\n", encoding="utf-8")
+            git(repo, "add", ".")
+            git(repo, "commit", "-m", "commit multiple leaks")
+
+            bin_dir = repo / "bin"
+            bin_dir.mkdir()
+            log = repo / "grep.log"
+            wrapper = bin_dir / "git"
+            wrapper.write_text(
+                (
+                    "#!/usr/bin/env sh\n"
+                    "if [ \"$1\" = \"grep\" ]; then\n"
+                    "  printf '%s\\n' \"$*\" >> \"$GIT_GREP_LOG\"\n"
+                    "fi\n"
+                    "exec \"$REAL_GIT\" \"$@\"\n"
+                ),
+                encoding="utf-8",
+            )
+            wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+            env["REAL_GIT"] = real_git or "git"
+            env["GIT_GREP_LOG"] = str(log)
+
+            result = subprocess.run(
+                [str(script), "--tree", "HEAD"],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("leak_one.txt", result.stderr)
+            self.assertIn("leak_two.txt", result.stderr)
+            self.assertEqual(log.read_text(encoding="utf-8").count("\n"), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_pii.py
+++ b/tests/test_check_pii.py
@@ -199,8 +199,10 @@ class CheckPiiTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 1)
-            self.assertIn("leak_one.txt", result.stderr)
-            self.assertIn("leak_two.txt", result.stderr)
+            expected_one = f"    HEAD:leak_one.txt:1:path={home_path}/one"
+            expected_two = f"    HEAD:leak_two.txt:1:path={home_path}/two"
+            self.assertIn(expected_one, result.stderr)
+            self.assertIn(expected_two, result.stderr)
             self.assertEqual(log.read_text(encoding="utf-8").count("\n"), 1)
 
 


### PR DESCRIPTION
This PR fixes `scripts/check_pii.sh --tree` so committed-tree scans run one `git grep` across the tree instead of spawning `git grep` once per tracked file.

The CLI and report format stay the same. The scanner still excludes `scripts/check_pii.sh` and `.pii-allow`, and `.pii-allow` still filters matched content rather than file locations.

Changes:

- Replace the per-file `git ls-tree` / `git grep` loop with one NUL-delimited tree-wide `git grep`.
- Preserve the existing `tree:path:line:content` report shape.
- Add a regression that wraps `git` and asserts tree mode invokes `git grep` once while reporting multiple leaking files.

Verification:

- `bash -n scripts/check_pii.sh`
- `python3 -B -m unittest tests.test_check_pii`
- `python3 -B -m unittest`
- `scripts/check_pii.sh --tree HEAD`
- `git diff --check`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`