### PR TITLE
feat: template_sync.sh — pull-mode drift check across downstream repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,38 @@ forces every worktree to share one directory and reintroduces the
 lock. Verify with `cargo metadata --format-version 1 --no-deps | jq -r .target_directory`
 in two worktrees — different paths = safe.
 
+## Syncing downstream forks
+
+Downstream repos seeded from this template (one per workspace) drift
+on the workflow tooling that template-rust owns canonically: the
+scripts under `scripts/`, the git hooks, the Claude command playbooks,
+the audit docs, the calibration/workflow prose, and the Python
+regression suite. `scripts/template_sync.sh` is a manifest-driven
+manual sync — pull-mode (the maintainer runs it from this repo
+against one or more downstream paths), opt-in `--apply`. It reports
+match / drift / missing for the verbatim set, and match / differs for
+the surgical set, but never auto-edits surgical paths.
+
+Surgical paths the maintainer still owes by hand:
+`AGENTS.md`, `Cargo.toml`, `rust-toolchain.toml`, `rustfmt.toml`,
+`deny.toml`, `.github/workflows/ci.yml`. These encode project-specific
+facts — MSRV, crate names, layer rules, dependency policy — and need a
+human merge.
+
+Typical use:
+
+```
+# Read-only drift check across one or more downstream repos:
+scripts/template_sync.sh ../downstream-a ../downstream-b
+
+# After reviewing the report, land the verbatim subset:
+scripts/template_sync.sh --apply ../downstream-a
+```
+
+`--apply` refuses a dirty downstream tree so the resulting `git diff`
+is exactly the sync, ready to land via the normal
+`plan/YYYY-MM-DD-NN` branch in the downstream.
+
 ## Workflow Is a State Machine
 
 The TDD and review workflow is a finite state machine, not a menu of

--- a/doc/audits/README.md
+++ b/doc/audits/README.md
@@ -125,3 +125,10 @@ scripts/audit_run.py run <name> --force --dry-run
 
 102 calendar fires/year, with far fewer Codex invocations because the
 early-exit gate skips no-change weeks.
+
+## See also
+
+`scripts/template_sync.sh` covers the orthogonal *cross-repo* drift
+between this template and downstream forks (workflow scripts, git
+hooks, Claude command playbooks, audit prose). See "Syncing
+downstream forks" in `AGENTS.md`.

--- a/doc/plans/plan-2026-05-08-03.md
+++ b/doc/plans/plan-2026-05-08-03.md
@@ -258,4 +258,67 @@ its Python regression test, not a parser, encoder, or data transform.
 
 ## Review
 
-(To be filled in at sprint close.)
+- All six task buckets (T1–T6) landed in a single `feat:` commit
+  (T1–T4 share the script file, T5 is the regression test, T6 is
+  prose; bundling matches conventional-commits style for an additive
+  feature).
+- T1's manifest is in-script bash arrays, not an external data file
+  (Deferred). The Python regression test at `tests/test_template_sync.py`
+  parses the arrays out of the script with a regex so the test
+  stays in lock-step with whatever the manifest says.
+- T2's drift report shows up to 40 lines of `diff -u` per drifted
+  verbatim file. Long enough to read at-a-glance; bounded so a fully
+  drifted downstream doesn't drown the terminal. Surgical paths get
+  no diff — they always differ, so the diff would just be noise.
+- T3 keeps `--apply`'s safety story to one rule (refuse dirty
+  downstream); a `--force` escape is Deferred. Existing-file overwrite
+  uses `install -m` with the source's mode (via `stat -f` on macOS,
+  `stat -c` on Linux) so githook executable bits survive.
+- T4's "refuse template-rust to itself" case fires when the script's
+  own working tree is passed as a downstream argument. The earlier
+  "must run from template-rust" guard is separate: it catches the
+  case where the script is invoked from a stale copy living inside a
+  downstream repo.
+- T5 covers all nine cases the plan listed plus a no-args usage check.
+  The test parses the manifest from the script, so adding a path is a
+  one-line script edit and the test still passes without touching
+  fixtures.
+- T6 added a "Syncing downstream forks" section to AGENTS.md (top-of-
+  file workflow prose) and a one-paragraph "See also" footer in
+  `doc/audits/README.md`. The doc/audits cross-reference is honest
+  about being orthogonal — within-repo automated audits vs cross-repo
+  manual sync — rather than blurring the two.
+
+### Drift caught
+
+- Initial smoke test against adat correctly flagged drift on
+  `scripts/check_pii.sh` (adat is on the pre-batch loop), `git_merge.sh`
+  (adat lacks the dirty-tree refusal upstream got later), and several
+  others — confirming the script does what the plan promised.
+- macOS bash 3.2 doesn't ship `declare -A`; first run hit
+  `declare: -A: invalid option`. Replaced the associative-array dedup
+  for downstream-arg duplicates with a linear scan over a regular
+  array. Bash 3.2 compatibility is the right floor — `bash` on stock
+  macOS is the bash that hooks run under.
+- `pwd` returned the `/var/folders/...` symlink form on macOS while
+  `git rev-parse --show-toplevel` returned the canonical `/private/var/...`
+  form, so the "must run from template-rust" guard misfired in the
+  test environment. Fixed by switching every `pwd` to `pwd -P`.
+
+### Recommendations
+
+- **Local-extension manifest tier.** Honor the Deferred "local
+  extension OK" entry by extending the manifest to a third tier (e.g.
+  `LOCAL_EXTENSION_PATHS`). The first concrete need is
+  `scripts/check_layers.sh`: adat's version legitimately diverges
+  (extra crate roots + `#[cfg(test)]` cutoff). Without this tier,
+  every adat sync run will report `check_layers.sh: drift` forever
+  even though the divergence is intentional.
+- **Externalize the manifest.** Once the path list grows past ~50
+  entries or starts wanting per-path metadata (severity, allowed
+  divergence, etc.), promote it to a TOML/YAML data file the script
+  parses. Until then, in-script arrays are fine and visible.
+- **Downstream `make sync` aliases.** Each downstream repo could ship
+  a Makefile target or shell alias that runs the template's script
+  with the right relative path, so the maintainer doesn't have to
+  type the absolute path each time. Out of scope for this sprint.

--- a/doc/plans/plan-2026-05-08-03.md
+++ b/doc/plans/plan-2026-05-08-03.md
@@ -1,0 +1,261 @@
+# Plan 03 - template_sync.sh: pull-mode drift check between template-rust and downstream repos
+
+## Goal
+
+Add `scripts/template_sync.sh <downstream-repo-path>...` so a downstream
+maintainer can detect (and optionally apply) drift on the set of files
+template-rust owns canonically, without manually diffing each path. The
+script encodes the path manifest; downstream repos pass themselves in as
+arguments. No repo names are hardcoded.
+
+## Context
+
+Downstream repos seeded from template-rust (e.g. one per Rust workspace
+in the maintainer's tree) accumulate drift on the workflow tooling that
+template-rust ships and curates: `scripts/`, `.githooks/`,
+`.claude/commands/`, `doc/audits/`, `doc/reviews/calibration.md`,
+`doc/workflow.md`, the Python regression suite under `tests/`, and the CI
+job that runs them. Today the only way to catch up is a per-file diff
+dance, which is exactly the toil that a downstream port sprint
+re-discovers each time. This script kills the 80% that is pure copy and
+flags the 20% that needs surgical merge.
+
+The script is **pull-mode only** (downstream chooses when to run it; no
+auto-PRs, no scheduled jobs) and **opt-in per file** (`--apply` is
+required to write; the default is read-only drift detection).
+
+## Reference points
+
+- Canonical-shared paths live in this repo and are listed in the
+  manifest below.
+- Downstream repo paths are CLI arguments. Running with multiple
+  downstream paths is allowed and runs the same checks against each.
+
+## Dependency Graph
+
+```text
+T1 -> T2 -> T3 -> T4 -> T5
+                  ^
+                  +-- T6 (docs) runs after T2-T4 land
+```
+
+T1 fixes the manifest data shape. T2 builds the read-only check path.
+T3 adds `--apply`. T4 covers refusal-to-clobber and dirty-tree guards.
+T5 is the Python regression test. T6 documents the script in AGENTS.md
+and points the audit doc at it.
+
+## Tasks
+
+### T1 - Manifest of canonical paths
+
+- Problem or motivation: the script needs a single data structure that
+  distinguishes "copy verbatim" paths from "surgical merge required"
+  paths. Hardcoding paths inside the script body makes the manifest
+  invisible to humans and tests.
+- Solution / implementation approach: define two arrays at the top of
+  the script:
+  - `VERBATIM_PATHS` - exact files/directories where downstream must
+    match template-rust byte-for-byte. Initial set:
+    - `scripts/audit_run.py`
+    - `scripts/audit_report.sh`
+    - `scripts/check_pii.sh`
+    - `scripts/check_layers.sh` (see Deferred for the local-extension
+      escape hatch)
+    - `scripts/git_merge.sh`
+    - `scripts/git_squash.sh`
+    - `scripts/github_client.py`
+    - `scripts/pr_report.py`
+    - `scripts/pr_request.sh`
+    - `scripts/pr_reply.py`
+    - `scripts/pr_review.sh`
+    - `scripts/workflow_state.sh`
+    - `.githooks/pre-commit`
+    - `.githooks/pre-push`
+    - `.claude/commands/pr-reply.md`
+    - `.claude/commands/pr-report.md`
+    - `.claude/commands/pr-review.md`
+    - `.claude/commands/pr-watch.md`
+    - `doc/audits/README.md`
+    - `doc/audits/docrot.md`
+    - `doc/audits/hygiene.md`
+    - `doc/audits/pii.md`
+    - `doc/reviews/calibration.md`
+    - `doc/workflow.md`
+    - `tests/__init__.py`
+    - `tests/test_audit_run.py`
+    - `tests/test_check_layers.py`
+    - `tests/test_check_pii.py`
+    - `tests/test_pr_report.py`
+    - `tests/test_pr_review.py`
+    - `tests/test_workflow_state.py`
+  - `SURGICAL_PATHS` - files where downstream must merge by hand
+    because they encode project-specific facts (MSRV, crate names,
+    layer rules, dependency policy). Initial set:
+    - `AGENTS.md`
+    - `Cargo.toml`
+    - `rust-toolchain.toml`
+    - `rustfmt.toml`
+    - `deny.toml`
+    - `.github/workflows/ci.yml`
+- Types or API surface: the manifest is internal to the script. Adding
+  a path is a one-line array edit.
+
+### T2 - Read-only check mode (default)
+
+- Problem or motivation: downstream needs to see drift before deciding
+  to apply anything.
+- Solution / implementation approach: invocation
+  `scripts/template_sync.sh <downstream-repo-path>...` (no flags). For
+  each downstream path:
+  - Resolve to an absolute path; refuse if it is not a git working
+    tree (`git -C <path> rev-parse --show-toplevel`).
+  - For each entry in `VERBATIM_PATHS`: compare the file in template-
+    rust HEAD against the file in `<downstream>/`. Report under one of
+    three buckets per downstream:
+    - `match` - byte-identical.
+    - `drift` - present on both sides but different. Print a unified
+      diff via `diff -u` capped at, say, 40 context lines, then a
+      one-line `path: drift (template -> downstream)` summary.
+    - `missing` - present in template, absent downstream. Print
+      `path: missing downstream`.
+  - For each entry in `SURGICAL_PATHS`: byte-compare and report only
+    `match` vs `differs (surgical merge required)`. Do not show a diff
+    — these files are expected to differ.
+- Exit code semantics:
+  - `0` if every downstream's verbatim set is `match` and surgical set
+    is either `match` or `differs` (no missing, no drift).
+  - `1` if any verbatim path is `drift` or `missing` (default mode is
+    a CI-friendly drift gate).
+  - `2` for argument or filesystem errors.
+- Types or API surface: positional arguments only.
+
+### T3 - `--apply` mode
+
+- Problem or motivation: after the maintainer has reviewed drift, they
+  need a one-shot copy of every verbatim path.
+- Solution / implementation approach: `--apply` flag (after positional
+  args, or before — getopt-style parsing is fine). For each downstream:
+  - Refuse if the downstream working tree is dirty (`git -C <path>
+    status --porcelain`). The point is to land sync changes as a
+    reviewable diff, not to silently mix them with local work.
+  - For each `VERBATIM_PATHS` entry: copy from
+    `template-rust/<path>` to `<downstream>/<path>` using `install -m`
+    so file mode is preserved (githooks must stay executable).
+  - For each `SURGICAL_PATHS` entry: do **not** copy. Print
+    `path: SKIP (surgical merge required)` and let the maintainer
+    handle it.
+  - After the copy pass, print a one-paragraph follow-up: how many
+    files were written, the surgical set the maintainer still owes,
+    and the suggested next step (`cd <downstream> && git status` /
+    `git diff` to review, then a normal `plan/YYYY-MM-DD-NN` branch
+    to land).
+- Types or API surface: `--apply` is the only writing flag. There is
+  no `--force` for dirty trees in this sprint (Deferred).
+
+### T4 - Refusal guards
+
+- Problem or motivation: silent overwrites are exactly the failure
+  mode this script must not introduce. Any guard that protects the
+  downstream from data loss earns its keep.
+- Solution / implementation approach:
+  - Refuse when invoked outside the template-rust working tree (the
+    script reads template content from the working tree, so its `cwd`
+    matters). Detect via `git rev-parse --show-toplevel` and compare
+    to the script's own `dirname`.
+  - Refuse when any positional argument is not a git repo.
+  - In `--apply` mode, refuse a dirty downstream tree.
+  - Refuse if the same downstream path is passed twice.
+- Types or API surface: error messages go to stderr; exit code 2.
+
+### T5 - Regression test
+
+- Problem or motivation: the manifest will grow over time, and the
+  refusal guards are exactly the kind of code that bit-rots silently.
+- Solution / implementation approach: add
+  `tests/test_template_sync.py`. Set up two temporary git repos in a
+  `tempfile.TemporaryDirectory`: a fake "template" repo containing
+  fixture copies of the script under test plus stub files at every
+  manifest path, and a fake "downstream" repo seeded from the same
+  fixtures. Cases:
+  - Pristine downstream: `template_sync.sh <downstream>` reports all
+    `match`, exits 0.
+  - One verbatim path edited downstream: exits 1, the diff appears in
+    stdout, the surgical set is reported as expected.
+  - Missing verbatim path downstream: exits 1, `missing` appears.
+  - `--apply` on a clean downstream: writes the drifted file, surgical
+    files are skipped.
+  - `--apply` on a dirty downstream: refuses, exit 2.
+  - Non-git downstream argument: refuses, exit 2.
+  - Duplicate downstream argument: refuses, exit 2.
+- Types or API surface: `tests/test_template_sync.py`. Wire it into
+  the existing `python3 -m unittest` suite (no CI change needed; it
+  already runs in `.github/workflows/ci.yml`).
+
+### T6 - Document and cross-link
+
+- Problem or motivation: a script no one knows about doesn't reduce
+  toil.
+- Solution / implementation approach:
+  - In `AGENTS.md`, add a short "Syncing downstream forks" section
+    near the top-level workflow prose. Two paragraphs:
+    1. Pull model, manifest-driven, opt-in `--apply`.
+    2. Surgical paths the maintainer still owes (AGENTS.md /
+       Cargo.toml / rust-toolchain.toml / rustfmt.toml / deny.toml /
+       .github/workflows/ci.yml).
+  - Add a one-line cross-reference from `doc/audits/README.md` ("see
+    `scripts/template_sync.sh` for cross-repo drift").
+
+## Verification
+
+### Properties (must pass)
+
+No proptest properties apply; this sprint adds a workflow script and
+its Python regression test, not a parser, encoder, or data transform.
+
+| Property | Module | Invariant |
+|----------|--------|-----------|
+
+### Spot checks
+
+| Check | Assertion |
+|-------|-----------|
+| `bash -n scripts/template_sync.sh` | New script is shell-syntax clean. |
+| `python3 -B -m unittest tests.test_template_sync` | All T5 cases green. |
+| `python3 -B -m unittest` | Full workflow regression suite green. |
+| `scripts/template_sync.sh <self>` against a fresh clone | Reports zero drift on day-one (manifest matches reality). |
+| `scripts/template_sync.sh ../adat` (manual) | Reports drift on whatever has accumulated since adat's last sync; `--apply` lands the verbatim subset; surgical set is named explicitly in the report. |
+
+### Build gates
+
+- `cargo build` - no Rust changes; should remain green.
+- `cargo test --workspace` - no regressions.
+- `cargo clippy --all-targets -- -D warnings` - no regressions.
+- End-to-end scenario: a downstream maintainer runs the script with
+  `--apply` after reviewing the drift report; the resulting `git
+  status` in the downstream shows exactly the verbatim drift, ready to
+  commit on a `plan/YYYY-MM-DD-NN` branch and ship through the normal
+  TDD workflow.
+
+## Deferred
+
+- **Local-extension escape hatch for `scripts/check_layers.sh`.**
+  adat needs a local extension to that script (extra crate roots, the
+  `#[cfg(test)]` cutoff). Listing it as `verbatim` will report drift
+  forever in adat. Two future options: (a) split the script into a
+  template-owned core plus a downstream-owned config file (preferred
+  long term), or (b) add a `LOCAL_EXTENSIONS_OK` flag to the manifest
+  for paths where downstream may diverge and the report should
+  downgrade `drift` to `local-extension`. Tracked here so the next
+  sprint that touches `check_layers.sh` evaluates this trade-off.
+- **`--apply --force` for dirty downstreams.** Out of scope; the
+  refusal guard is the safety story for v1.
+- **Auto-commit / auto-PR in the downstream.** Explicit non-goal; the
+  pull model lets the maintainer hand-craft the commit on a
+  plan-branch.
+- **Manifest-as-data file** (e.g. `template_sync.toml`). Could replace
+  the in-script arrays once the manifest stabilizes; deferred until
+  the script has earned the right to grow that complexity.
+
+## Review
+
+(To be filled in at sprint close.)

--- a/doc/reviews/review-00027.md
+++ b/doc/reviews/review-00027.md
@@ -1,0 +1,65 @@
+# PR #27 — `scripts/template_sync.sh`: pull-mode drift check across downstream repos
+
+## Summary
+
+Adds `scripts/template_sync.sh` so a maintainer can detect (and
+optionally apply) drift between this template and downstream repos
+seeded from it, without manually diffing each path.
+
+### What changed
+
+- `scripts/template_sync.sh` (new). Manifest-driven sync between
+  template-rust and downstream forks. Two arrays at the top of the
+  script:
+  - `VERBATIM_PATHS` — files where downstream must match template-rust
+    byte-for-byte (workflow scripts under `scripts/`, the two git
+    hooks, the four `.claude/commands/*.md`, audit prose under
+    `doc/audits/`, `doc/reviews/calibration.md`, `doc/workflow.md`,
+    and the Python regression suite under `tests/`).
+  - `SURGICAL_PATHS` — files that always differ per project
+    (`AGENTS.md`, `Cargo.toml`, `rust-toolchain.toml`, `rustfmt.toml`,
+    `deny.toml`, `.github/workflows/ci.yml`). Reported but never
+    auto-copied.
+- Default mode is read-only drift: report `match` / `drift` / `missing`
+  for verbatim, `match` / `differs` for surgical. Exit 1 if any
+  verbatim path drifted or is missing — CI-friendly.
+- `--apply` mode copies the verbatim subset using `install -m` so
+  githook executable bits survive. Refuses a dirty downstream tree;
+  surgical paths are explicitly skipped with a one-line note.
+- Refusal guards: not in template-rust working tree, non-git
+  downstream argument, dirty downstream under `--apply`, duplicate
+  downstream argument, or downstream pointing at template-rust itself.
+- Downstream paths are positional CLI arguments; no repo names are
+  encoded in the script.
+- `tests/test_template_sync.py` (new). Nine cases covering pristine
+  match, drift, missing-file, `--apply` happy-path, dirty refusal,
+  non-git refusal, duplicate-arg refusal, self-sync refusal, and
+  no-args usage. Parses the manifest out of the script with a regex
+  so adding a verbatim/surgical path doesn't require editing
+  fixtures.
+- `AGENTS.md` (modified). New "Syncing downstream forks" section near
+  the top with the surgical-path list and a typical invocation.
+- `doc/audits/README.md` (modified). One-paragraph "See also" footer
+  pointing at the new script.
+
+### Verification
+
+- `bash -n scripts/template_sync.sh`: clean.
+- `python3 -m unittest`: 22 passed (9 new for `test_template_sync`).
+- `cargo test --workspace`: green.
+- `cargo clippy --all-targets -- -D warnings`: green.
+- `cargo fmt --all -- --check`: green.
+- `scripts/template_sync.sh ../adat`: reports drift on adat's
+  pre-batch `check_pii.sh`, the local-extension `check_layers.sh`,
+  and the older `git_merge.sh` — exit 1 as designed.
+
+### Deferred
+
+- **Local-extension manifest tier.** A future third tier
+  (`LOCAL_EXTENSION_PATHS`) for paths where downstream may diverge
+  intentionally — the immediate need is `scripts/check_layers.sh`
+  for adat (extra crate roots + `#[cfg(test)]` cutoff). Without it,
+  adat's sync will always report `check_layers.sh: drift`.
+- **`--apply --force`** for dirty downstreams.
+- **Externalized manifest** (e.g. `template_sync.toml`).
+- **Auto-commit / auto-PR**. Out of scope by design — pull model only.

--- a/doc/reviews/review-00027.md
+++ b/doc/reviews/review-00027.md
@@ -63,3 +63,23 @@ seeded from it, without manually diffing each path.
 - **`--apply --force`** for dirty downstreams.
 - **Externalized manifest** (e.g. `template_sync.toml`).
 - **Auto-commit / auto-PR**. Out of scope by design — pull model only.
+
+## Local review (2026-05-08)
+
+**Branch:** plan/2026-05-08-03
+**Commits:** 3 (origin/main..plan/2026-05-08-03)
+**Reviewer:** Codex (`codex review --base origin/main`)
+**Prompt fingerprint:** AGENTS.md=02d75717d4a011a259975a8871afb571ef13ccc8 calibration=da4563c5de79900526f1af39c38320bea4cee6c5
+
+---
+
+The new --apply path is not portable to the Ubuntu CI environment and will fail when copying drifted files. The manifest also omits the newly added sync artifacts, so downstream repos cannot be fully brought up to date by the tool.
+
+Full review comments:
+
+- [P1] Use a portable mode lookup before install — scripts/template_sync.sh:237-237
+  On Ubuntu/GNU coreutils, including this repo's CI runner, `stat -f` does not take a format argument; it treats `'%Lp'` as a filename and can still print filesystem information for `$src` before the fallback `stat -c` runs. For any `--apply` that copies a drifted file, `install -m "$(...)"` receives a multi-line/non-octal mode and fails, which also breaks the new unittest apply case in CI; the identical expression in the missing-file branch needs the same fix.
+
+- [P2] Add new sync artifacts to the manifest — scripts/template_sync.sh:50-50
+  `--apply` only copies paths listed in `VERBATIM_PATHS`, but this PR adds `scripts/template_sync.sh` and `tests/test_template_sync.py` without listing either one. A downstream updated with the new tool will therefore still be missing the sync tool and its regression test, even though the docs describe the `scripts/` tooling and Python regression suite as canonical downstream-owned files.
+

--- a/scripts/template_sync.sh
+++ b/scripts/template_sync.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# template_sync.sh — pull-mode drift check between template-rust and
+# downstream repos seeded from it.
+#
+# template-rust owns a small set of "canonical-shared" files outright:
+# workflow scripts, git hooks, the Claude command playbooks, the audit
+# docs, the calibration/workflow prose, and the Python regression
+# suite. Downstream repos (one per workspace seeded from this one) get
+# stale on those files because there's no automated sync. This script
+# is the manifest-driven manual sync.
+#
+# Modes:
+#   default          read-only drift report; exits non-zero if any
+#                    verbatim path drifted or is missing.
+#   --apply          for each downstream, copy every verbatim path
+#                    from this working tree into the downstream
+#                    working tree. Skips surgical paths and refuses
+#                    a dirty downstream tree.
+#
+# Surgical paths (AGENTS.md, Cargo.toml, rust-toolchain.toml,
+# rustfmt.toml, deny.toml, .github/workflows/ci.yml) are reported as
+# match-vs-differs only. They encode project-specific facts (MSRV,
+# crate names, layer rules, dependency policy) and need a human
+# merge — never auto-copied.
+#
+# Usage:
+#   scripts/template_sync.sh <downstream-repo-path>...
+#   scripts/template_sync.sh --apply <downstream-repo-path>...
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  scripts/template_sync.sh <downstream-repo-path>...
+  scripts/template_sync.sh --apply <downstream-repo-path>...
+
+Without --apply, prints a drift report for each downstream repo and
+exits 1 if any verbatim path drifted or is missing. With --apply,
+copies every verbatim path from this working tree into each downstream
+(refuses a dirty downstream tree). Surgical paths are reported but
+never copied.
+USAGE
+}
+
+# --- Manifest ---------------------------------------------------------
+#
+# Adding a path is a one-line array edit. Keep VERBATIM and SURGICAL
+# disjoint; the report has no bucket for "in both."
+
+VERBATIM_PATHS=(
+  "scripts/audit_run.py"
+  "scripts/audit_report.sh"
+  "scripts/check_pii.sh"
+  "scripts/check_layers.sh"
+  "scripts/git_merge.sh"
+  "scripts/git_squash.sh"
+  "scripts/github_client.py"
+  "scripts/pr_report.py"
+  "scripts/pr_request.sh"
+  "scripts/pr_reply.py"
+  "scripts/pr_review.sh"
+  "scripts/workflow_state.sh"
+  ".githooks/pre-commit"
+  ".githooks/pre-push"
+  ".claude/commands/pr-reply.md"
+  ".claude/commands/pr-report.md"
+  ".claude/commands/pr-review.md"
+  ".claude/commands/pr-watch.md"
+  "doc/audits/README.md"
+  "doc/audits/docrot.md"
+  "doc/audits/hygiene.md"
+  "doc/audits/pii.md"
+  "doc/reviews/calibration.md"
+  "doc/workflow.md"
+  "tests/__init__.py"
+  "tests/test_audit_run.py"
+  "tests/test_check_layers.py"
+  "tests/test_check_pii.py"
+  "tests/test_pr_report.py"
+  "tests/test_pr_review.py"
+  "tests/test_workflow_state.py"
+)
+
+SURGICAL_PATHS=(
+  "AGENTS.md"
+  "Cargo.toml"
+  "rust-toolchain.toml"
+  "rustfmt.toml"
+  "deny.toml"
+  ".github/workflows/ci.yml"
+)
+
+# --- Argument parsing -------------------------------------------------
+
+apply=false
+declare -a downstream_args
+downstream_args=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --apply)
+      apply=true
+      shift
+      ;;
+    --)
+      shift
+      while [ $# -gt 0 ]; do
+        downstream_args+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "template_sync.sh: unknown flag: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      downstream_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ ${#downstream_args[@]} -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+# --- Resolve template-rust root and validate cwd ----------------------
+
+script_dir=$(cd "$(dirname "$0")" && pwd -P)
+template_root=$(cd "$script_dir/.." && pwd -P)
+
+# Refuse to run from a worktree that isn't this template repo. The
+# script reads template content from `$template_root`; if the user
+# accidentally invoked it via a symlink from a downstream repo, the
+# "template" side would be whatever stale copy lives there.
+if ! template_git_root=$(git -C "$template_root" rev-parse --show-toplevel 2>/dev/null); then
+  echo "template_sync.sh: $template_root is not a git working tree." >&2
+  exit 2
+fi
+if [ "$template_git_root" != "$template_root" ]; then
+  echo "template_sync.sh: script must run from the template-rust working tree." >&2
+  echo "  resolved template root: $template_root" >&2
+  echo "  git toplevel:           $template_git_root" >&2
+  exit 2
+fi
+
+# --- Validate downstream args -----------------------------------------
+
+declare -a downstream_roots
+downstream_roots=()
+
+for raw in "${downstream_args[@]}"; do
+  if [ ! -d "$raw" ]; then
+    echo "template_sync.sh: downstream path is not a directory: $raw" >&2
+    exit 2
+  fi
+  if ! abs=$(cd "$raw" && pwd -P); then
+    echo "template_sync.sh: cannot enter downstream path: $raw" >&2
+    exit 2
+  fi
+  if ! down_git_root=$(git -C "$abs" rev-parse --show-toplevel 2>/dev/null); then
+    echo "template_sync.sh: downstream path is not a git working tree: $raw" >&2
+    exit 2
+  fi
+  if [ "$down_git_root" = "$template_root" ]; then
+    echo "template_sync.sh: refusing to sync template-rust to itself: $raw" >&2
+    exit 2
+  fi
+  if [ ${#downstream_roots[@]} -gt 0 ]; then
+    for prev in "${downstream_roots[@]}"; do
+      if [ "$prev" = "$down_git_root" ]; then
+        echo "template_sync.sh: downstream path passed twice: $raw" >&2
+        exit 2
+      fi
+    done
+  fi
+  downstream_roots+=("$down_git_root")
+done
+
+# --- Per-downstream processing ----------------------------------------
+
+overall_drift=0
+
+report_one() {
+  local downstream="$1"
+  local heading="=== $downstream ==="
+  printf '%s\n' "$heading"
+
+  if [ "$apply" = true ]; then
+    if [ -n "$(git -C "$downstream" status --porcelain)" ]; then
+      echo "template_sync.sh: refusing --apply on dirty downstream: $downstream" >&2
+      echo "  commit or stash local changes first." >&2
+      exit 2
+    fi
+  fi
+
+  local drift_count=0
+  local missing_count=0
+  local applied_count=0
+  local match_count=0
+  local surgical_match=0
+  local surgical_diff=0
+  local rel src dst
+
+  for rel in "${VERBATIM_PATHS[@]}"; do
+    src="$template_root/$rel"
+    dst="$downstream/$rel"
+    if [ ! -e "$src" ]; then
+      echo "  $rel: SKIP (manifest entry missing in template)" >&2
+      continue
+    fi
+    if [ ! -e "$dst" ]; then
+      printf '  %s: missing downstream\n' "$rel"
+      missing_count=$((missing_count + 1))
+      if [ "$apply" = true ]; then
+        mkdir -p "$(dirname "$dst")"
+        install -m "$(stat -f '%Lp' "$src" 2>/dev/null || stat -c '%a' "$src")" "$src" "$dst"
+        applied_count=$((applied_count + 1))
+      fi
+      continue
+    fi
+    if cmp -s "$src" "$dst"; then
+      match_count=$((match_count + 1))
+      continue
+    fi
+    printf '  %s: drift\n' "$rel"
+    diff -u --label "template/$rel" --label "downstream/$rel" \
+      "$src" "$dst" | sed -n '1,40p' || true
+    drift_count=$((drift_count + 1))
+    if [ "$apply" = true ]; then
+      install -m "$(stat -f '%Lp' "$src" 2>/dev/null || stat -c '%a' "$src")" "$src" "$dst"
+      applied_count=$((applied_count + 1))
+    fi
+  done
+
+  for rel in "${SURGICAL_PATHS[@]}"; do
+    src="$template_root/$rel"
+    dst="$downstream/$rel"
+    if [ ! -e "$src" ]; then
+      continue
+    fi
+    if [ ! -e "$dst" ]; then
+      printf '  %s: missing downstream (surgical — not auto-copied)\n' "$rel"
+      surgical_diff=$((surgical_diff + 1))
+      continue
+    fi
+    if cmp -s "$src" "$dst"; then
+      surgical_match=$((surgical_match + 1))
+      continue
+    fi
+    printf '  %s: differs (surgical merge required)\n' "$rel"
+    surgical_diff=$((surgical_diff + 1))
+  done
+
+  printf '  summary: verbatim match=%d drift=%d missing=%d' \
+    "$match_count" "$drift_count" "$missing_count"
+  if [ "$apply" = true ]; then
+    printf ' applied=%d' "$applied_count"
+  fi
+  printf '  surgical match=%d differs=%d\n' "$surgical_match" "$surgical_diff"
+
+  if [ "$drift_count" -gt 0 ] || [ "$missing_count" -gt 0 ]; then
+    overall_drift=1
+  fi
+}
+
+for downstream in "${downstream_roots[@]}"; do
+  report_one "$downstream"
+done
+
+if [ "$apply" = true ]; then
+  cat <<'NEXT'
+
+template_sync.sh: --apply done.
+Surgical paths were reported but never copied; merge them by hand
+where the report says "differs (surgical merge required)".
+Review each downstream with `git -C <path> status` / `git diff` and
+land via the normal plan/YYYY-MM-DD-NN branch.
+NEXT
+  exit 0
+fi
+
+exit "$overall_drift"

--- a/scripts/template_sync.sh
+++ b/scripts/template_sync.sh
@@ -59,6 +59,7 @@ VERBATIM_PATHS=(
   "scripts/pr_request.sh"
   "scripts/pr_reply.py"
   "scripts/pr_review.sh"
+  "scripts/template_sync.sh"
   "scripts/workflow_state.sh"
   ".githooks/pre-commit"
   ".githooks/pre-push"
@@ -78,6 +79,7 @@ VERBATIM_PATHS=(
   "tests/test_check_pii.py"
   "tests/test_pr_report.py"
   "tests/test_pr_review.py"
+  "tests/test_template_sync.py"
   "tests/test_workflow_state.py"
 )
 
@@ -220,7 +222,7 @@ report_one() {
       missing_count=$((missing_count + 1))
       if [ "$apply" = true ]; then
         mkdir -p "$(dirname "$dst")"
-        install -m "$(stat -f '%Lp' "$src" 2>/dev/null || stat -c '%a' "$src")" "$src" "$dst"
+        install -m "$(stat -c '%a' "$src" 2>/dev/null || stat -f '%Lp' "$src")" "$src" "$dst"
         applied_count=$((applied_count + 1))
       fi
       continue
@@ -234,7 +236,7 @@ report_one() {
       "$src" "$dst" | sed -n '1,40p' || true
     drift_count=$((drift_count + 1))
     if [ "$apply" = true ]; then
-      install -m "$(stat -f '%Lp' "$src" 2>/dev/null || stat -c '%a' "$src")" "$src" "$dst"
+      install -m "$(stat -c '%a' "$src" 2>/dev/null || stat -f '%Lp' "$src")" "$src" "$dst"
       applied_count=$((applied_count + 1))
     fi
   done

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_SYNC_PATH = REPO_ROOT / "scripts" / "template_sync.sh"
+
+
+def git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def parse_manifest(script_text: str, name: str) -> list[str]:
+    """Extract a bash array literal of double-quoted strings from the script."""
+    match = re.search(rf"^{re.escape(name)}=\((.*?)^\)", script_text, re.M | re.S)
+    if not match:
+        raise AssertionError(f"manifest array {name} not found in script")
+    body = match.group(1)
+    return re.findall(r'"([^"]+)"', body)
+
+
+class TemplateSyncTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.script_text = TEMPLATE_SYNC_PATH.read_text(encoding="utf-8")
+        cls.verbatim = parse_manifest(cls.script_text, "VERBATIM_PATHS")
+        cls.surgical = parse_manifest(cls.script_text, "SURGICAL_PATHS")
+        # Both sets must be non-empty for the tests to be meaningful.
+        if not cls.verbatim or not cls.surgical:
+            raise AssertionError("manifest arrays parsed empty")
+
+    def _make_template(self, root: Path) -> None:
+        """Create a fake template-rust working tree at `root`."""
+        root.mkdir(parents=True, exist_ok=True)
+        git(root, "init", "--initial-branch=main")
+        git(root, "config", "user.name", "Template Sync Test")
+        git(root, "config", "user.email", "tst@example.invalid")
+
+        scripts = root / "scripts"
+        scripts.mkdir(parents=True, exist_ok=True)
+        sync = scripts / "template_sync.sh"
+        sync.write_text(self.script_text, encoding="utf-8")
+        sync.chmod(sync.stat().st_mode | stat.S_IXUSR)
+
+        # Populate every manifest path with a deterministic stub.
+        for rel in [*self.verbatim, *self.surgical]:
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(f"template stub: {rel}\n", encoding="utf-8")
+
+        git(root, "add", ".")
+        git(root, "commit", "-m", "template fixture")
+
+    def _make_downstream(self, root: Path, template: Path) -> None:
+        """Create a downstream that exactly mirrors the template's manifest paths."""
+        root.mkdir(parents=True, exist_ok=True)
+        git(root, "init", "--initial-branch=main")
+        git(root, "config", "user.name", "Template Sync Test")
+        git(root, "config", "user.email", "tst@example.invalid")
+
+        for rel in [*self.verbatim, *self.surgical]:
+            src = template / rel
+            dst = root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+        git(root, "add", ".")
+        git(root, "commit", "-m", "downstream fixture")
+
+    def _run_sync(
+        self, template: Path, *args: str
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(template / "scripts" / "template_sync.sh"), *args],
+            cwd=template,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_pristine_downstream_reports_match_and_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            downstream = tmp / "downstream"
+            self._make_template(template)
+            self._make_downstream(downstream, template)
+
+            r = self._run_sync(template, str(downstream))
+
+            self.assertEqual(r.returncode, 0, msg=f"stdout={r.stdout!r} stderr={r.stderr!r}")
+            self.assertNotIn(": drift\n", r.stdout)
+            self.assertNotIn(": missing downstream\n", r.stdout)
+
+    def test_edited_verbatim_path_reports_drift_and_exits_one(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            downstream = tmp / "downstream"
+            self._make_template(template)
+            self._make_downstream(downstream, template)
+
+            target = self.verbatim[0]
+            (downstream / target).write_text("DOWNSTREAM EDITED\n", encoding="utf-8")
+            git(downstream, "add", target)
+            git(downstream, "commit", "-m", "downstream drift")
+
+            r = self._run_sync(template, str(downstream))
+
+            self.assertEqual(r.returncode, 1, msg=f"stdout={r.stdout!r}")
+            self.assertIn(f"  {target}: drift", r.stdout)
+            self.assertIn("DOWNSTREAM EDITED", r.stdout)
+
+    def test_missing_verbatim_path_reports_missing_and_exits_one(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            downstream = tmp / "downstream"
+            self._make_template(template)
+            self._make_downstream(downstream, template)
+
+            target = self.verbatim[1]
+            (downstream / target).unlink()
+            git(downstream, "add", "-A")
+            git(downstream, "commit", "-m", "remove verbatim path")
+
+            r = self._run_sync(template, str(downstream))
+
+            self.assertEqual(r.returncode, 1)
+            self.assertIn(f"  {target}: missing downstream", r.stdout)
+
+    def test_apply_writes_drifted_file_and_skips_surgical(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            downstream = tmp / "downstream"
+            self._make_template(template)
+            self._make_downstream(downstream, template)
+
+            verbatim_target = self.verbatim[0]
+            surgical_target = self.surgical[0]
+            (downstream / verbatim_target).write_text("DRIFT\n", encoding="utf-8")
+            (downstream / surgical_target).write_text("SURGICAL DRIFT\n", encoding="utf-8")
+            git(downstream, "add", "-A")
+            git(downstream, "commit", "-m", "downstream drift")
+
+            r = self._run_sync(template, "--apply", str(downstream))
+
+            self.assertEqual(r.returncode, 0, msg=f"stderr={r.stderr!r}")
+            # Verbatim path was overwritten with template content.
+            self.assertEqual(
+                (downstream / verbatim_target).read_text(encoding="utf-8"),
+                (template / verbatim_target).read_text(encoding="utf-8"),
+            )
+            # Surgical path was left alone (still says "SURGICAL DRIFT").
+            self.assertEqual(
+                (downstream / surgical_target).read_text(encoding="utf-8"),
+                "SURGICAL DRIFT\n",
+            )
+            self.assertIn("differs (surgical merge required)", r.stdout)
+
+    def test_apply_refuses_dirty_downstream(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            downstream = tmp / "downstream"
+            self._make_template(template)
+            self._make_downstream(downstream, template)
+
+            (downstream / self.verbatim[0]).write_text("DIRTY\n", encoding="utf-8")
+            # Note: not committed — working tree is dirty.
+
+            r = self._run_sync(template, "--apply", str(downstream))
+
+            self.assertEqual(r.returncode, 2)
+            self.assertIn("refusing --apply on dirty downstream", r.stderr)
+
+    def test_non_git_downstream_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            self._make_template(template)
+            non_git = tmp / "not_a_repo"
+            non_git.mkdir()
+
+            r = self._run_sync(template, str(non_git))
+
+            self.assertEqual(r.returncode, 2)
+            self.assertIn("not a git working tree", r.stderr)
+
+    def test_duplicate_downstream_argument_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            downstream = tmp / "downstream"
+            self._make_template(template)
+            self._make_downstream(downstream, template)
+
+            r = self._run_sync(template, str(downstream), str(downstream))
+
+            self.assertEqual(r.returncode, 2)
+            self.assertIn("passed twice", r.stderr)
+
+    def test_self_sync_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            self._make_template(template)
+
+            r = self._run_sync(template, str(template))
+
+            self.assertEqual(r.returncode, 2)
+            self.assertIn("template-rust to itself", r.stderr)
+
+    def test_no_arguments_prints_usage(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            template = tmp / "template"
+            self._make_template(template)
+
+            r = self._run_sync(template)
+
+            self.assertEqual(r.returncode, 2)
+            self.assertIn("usage:", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -48,17 +48,18 @@ class TemplateSyncTests(unittest.TestCase):
         git(root, "config", "user.name", "Template Sync Test")
         git(root, "config", "user.email", "tst@example.invalid")
 
-        scripts = root / "scripts"
-        scripts.mkdir(parents=True, exist_ok=True)
-        sync = scripts / "template_sync.sh"
-        sync.write_text(self.script_text, encoding="utf-8")
-        sync.chmod(sync.stat().st_mode | stat.S_IXUSR)
-
-        # Populate every manifest path with a deterministic stub.
+        # Populate every manifest path with a deterministic stub. Then
+        # overwrite the entries that need real content (the script
+        # itself, and its regression test) so the manifest's
+        # self-references don't get clobbered with stubs.
         for rel in [*self.verbatim, *self.surgical]:
             p = root / rel
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(f"template stub: {rel}\n", encoding="utf-8")
+
+        sync = root / "scripts" / "template_sync.sh"
+        sync.write_text(self.script_text, encoding="utf-8")
+        sync.chmod(sync.stat().st_mode | stat.S_IXUSR)
 
         git(root, "add", ".")
         git(root, "commit", "-m", "template fixture")


### PR DESCRIPTION
Adds `scripts/template_sync.sh` so a maintainer can detect (and
optionally apply) drift between this template and downstream repos
seeded from it, without manually diffing each path.

### What changed

- `scripts/template_sync.sh` (new). Manifest-driven sync between
  template-rust and downstream forks. Two arrays at the top of the
  script:
  - `VERBATIM_PATHS` — files where downstream must match template-rust
    byte-for-byte (workflow scripts under `scripts/`, the two git
    hooks, the four `.claude/commands/*.md`, audit prose under
    `doc/audits/`, `doc/reviews/calibration.md`, `doc/workflow.md`,
    and the Python regression suite under `tests/`).
  - `SURGICAL_PATHS` — files that always differ per project
    (`AGENTS.md`, `Cargo.toml`, `rust-toolchain.toml`, `rustfmt.toml`,
    `deny.toml`, `.github/workflows/ci.yml`). Reported but never
    auto-copied.
- Default mode is read-only drift: report `match` / `drift` / `missing`
  for verbatim, `match` / `differs` for surgical. Exit 1 if any
  verbatim path drifted or is missing — CI-friendly.
- `--apply` mode copies the verbatim subset using `install -m` so
  githook executable bits survive. Refuses a dirty downstream tree;
  surgical paths are explicitly skipped with a one-line note.
- Refusal guards: not in template-rust working tree, non-git
  downstream argument, dirty downstream under `--apply`, duplicate
  downstream argument, or downstream pointing at template-rust itself.
- Downstream paths are positional CLI arguments; no repo names are
  encoded in the script.
- `tests/test_template_sync.py` (new). Nine cases covering pristine
  match, drift, missing-file, `--apply` happy-path, dirty refusal,
  non-git refusal, duplicate-arg refusal, self-sync refusal, and
  no-args usage. Parses the manifest out of the script with a regex
  so adding a verbatim/surgical path doesn't require editing
  fixtures.
- `AGENTS.md` (modified). New "Syncing downstream forks" section near
  the top with the surgical-path list and a typical invocation.
- `doc/audits/README.md` (modified). One-paragraph "See also" footer
  pointing at the new script.

### Verification

- `bash -n scripts/template_sync.sh`: clean.
- `python3 -m unittest`: 22 passed (9 new for `test_template_sync`).
- `cargo test --workspace`: green.
- `cargo clippy --all-targets -- -D warnings`: green.
- `cargo fmt --all -- --check`: green.
- `scripts/template_sync.sh ../adat`: reports drift on adat's
  pre-batch `check_pii.sh`, the local-extension `check_layers.sh`,
  and the older `git_merge.sh` — exit 1 as designed.

### Deferred

- **Local-extension manifest tier.** A future third tier
  (`LOCAL_EXTENSION_PATHS`) for paths where downstream may diverge
  intentionally — the immediate need is `scripts/check_layers.sh`
  for adat (extra crate roots + `#[cfg(test)]` cutoff). Without it,
  adat's sync will always report `check_layers.sh: drift`.
- **`--apply --force`** for dirty downstreams.
- **Externalized manifest** (e.g. `template_sync.toml`).
- **Auto-commit / auto-PR**. Out of scope by design — pull model only.
